### PR TITLE
support  c++20 compilation

### DIFF
--- a/yacl/base/exception.h
+++ b/yacl/base/exception.h
@@ -54,12 +54,20 @@ namespace internal {
 
 const int kMaxStackTraceDep = 16;
 
+#if __cplusplus >= 202002L
 template <typename... Args>
 inline std::string Format(fmt::format_string<Args...> f, Args&&... args) {
   return fmt::format(f, std::forward<Args>(args)...);
 }
+#else
+template <typename... Args>
+inline std::string Format(Args&&... args) {
+  return fmt::format(std::forward<Args>(args)...);
+}
+#endif
 
 // Trick to make Format works with empty arguments.
+template <>
 inline std::string Format() {
   return "";
 }

--- a/yacl/base/exception.h
+++ b/yacl/base/exception.h
@@ -60,7 +60,6 @@ inline std::string Format(Args&&... args) {
 }
 
 // Trick to make Format works with empty arguments.
-template <>
 inline std::string Format() {
   return "";
 }

--- a/yacl/base/exception.h
+++ b/yacl/base/exception.h
@@ -67,7 +67,10 @@ inline std::string Format(Args&&... args) {
 #endif
 
 // Trick to make Format works with empty arguments.
+#if __cplusplus >= 202002L
+#else
 template <>
+#endif
 inline std::string Format() {
   return "";
 }

--- a/yacl/base/exception.h
+++ b/yacl/base/exception.h
@@ -55,8 +55,8 @@ namespace internal {
 const int kMaxStackTraceDep = 16;
 
 template <typename... Args>
-inline std::string Format(Args&&... args) {
-  return fmt::format(std::forward<Args>(args)...);
+inline std::string Format(fmt::format_string<Args...> f, Args&&... args) {
+  return fmt::format(f, std::forward<Args>(args)...);
 }
 
 // Trick to make Format works with empty arguments.

--- a/yacl/base/int128.h
+++ b/yacl/base/int128.h
@@ -102,11 +102,17 @@ struct is_scalar<uint128_t> : public true_type {};
 template <>
 struct is_scalar<int128_t> : public true_type {};
 
+#if __cplusplus >= 202002L
+//-std=gnu++20 pass, -std=c++20 failed
+static_assert(is_integral<uint128_t>::value == true);
+static_assert(is_integral<int128_t>::value == true);
+#else
 template <>
 struct is_integral<uint128_t> : public true_type {};
 
 template <>
 struct is_integral<int128_t> : public true_type {};
+#endif
 
 template <>
 struct is_arithmetic<int128_t> : public true_type {};

--- a/yacl/base/int128.h
+++ b/yacl/base/int128.h
@@ -88,7 +88,10 @@ std::pair<uint64_t, uint64_t> DecomposeUInt128(uint128_t v);
 
 namespace std {
 
+#if __cplusplus >= 202002L
+#else
 constexpr int128_t abs(int128_t x) { return x >= 0 ? x : -x; }
+#endif
 
 constexpr int128_t abs(uint128_t x) { return x; }
 

--- a/yacl/crypto/base/ecc/ec_point.h
+++ b/yacl/crypto/base/ecc/ec_point.h
@@ -102,3 +102,10 @@ using Array160 =
 using EcPoint = std::variant<Array32, Array160, AnyPointPtr, AffinePoint>;
 
 }  // namespace yacl::crypto
+
+#if __cplusplus >= 202002L
+namespace fmt {
+template <>
+struct formatter<yacl::crypto::AffinePoint> : ostream_formatter {};
+}  // namespace fmt
+#endif

--- a/yacl/crypto/base/ecc/libsodium/sodium_group.h
+++ b/yacl/crypto/base/ecc/libsodium/sodium_group.h
@@ -29,7 +29,10 @@ struct CurveParam {
   MPInt n;
   MPInt h;
 
+#if __cplusplus >= 202002L
+#else
   CurveParam() = default;
+#endif
 };
 
 class SodiumGroup : public EcGroupSketch {

--- a/yacl/crypto/base/ecc/toy/common.h
+++ b/yacl/crypto/base/ecc/toy/common.h
@@ -28,7 +28,10 @@ struct CurveParam {
   MPInt n;
   MPInt h;
 
+#if __cplusplus >= 202002L
+#else
   CurveParam() = default;
+#endif
 };
 
 // base class of Toy lib

--- a/yacl/crypto/base/mpint/mp_int.h
+++ b/yacl/crypto/base/mpint/mp_int.h
@@ -408,6 +408,6 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
 #if __cplusplus >= 202002L
 namespace fmt {
 template <>
-struct formatter<MPInt> : ostream_formatter {};
+struct formatter<yacl::crypto::MPInt> : ostream_formatter {};
 }  // namespace fmt
 #endif

--- a/yacl/crypto/base/mpint/mp_int.h
+++ b/yacl/crypto/base/mpint/mp_int.h
@@ -403,3 +403,11 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
   }  // namespace adaptor
 }  // MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
 }  // namespace msgpack
+
+//since c++20 deleted overloads for basic_ostream and UTF character/array
+#if __cplusplus >= 202002L
+namespace fmt {
+template <>
+struct formatter<MPInt> : ostream_formatter {};
+}  // namespace fmt
+#endif

--- a/yacl/utils/parallel_common.cc
+++ b/yacl/utils/parallel_common.cc
@@ -15,7 +15,7 @@ size_t get_env_num_threads(const char* var_name, size_t def_value = 0) {
       return nthreads;
     }
   } catch (const std::exception& e) {
-    YACL_ENFORCE("Invalid {} variable value: {}", var_name, e.what());
+    YACL_THROW("Invalid {} variable value: {}", var_name, e.what());
   }
   return def_value;
 }


### PR DESCRIPTION
1> about uint128_t int128_t,  -std=c++20 think their is not c pod type, thus is_integral will be false, but -std=gnu++20 on the contrary;

2> about fmtlib,  to format custom class with-std=c++20,  must specifician formatter.  now i only change code in yacl/crypto/base/ecc

3> about default construct, since c++20, it will clash with default init list construct;