### PR TITLE
Update Protobuf to 21.12

### DIFF
--- a/bazel/patches/brpc_pb.patch
+++ b/bazel/patches/brpc_pb.patch
@@ -1,0 +1,317 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2eeec04976..9df7f1efec 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,7 +15,7 @@
+ # specific language governing permissions and limitations
+ # under the License.
+ 
+-cmake_minimum_required(VERSION 2.8.10)
++cmake_minimum_required(VERSION 2.8.12)
+ project(brpc C CXX)
+ 
+ option(WITH_GLOG "With glog" OFF)
+@@ -140,8 +140,6 @@ else()
+ endif()
+ endmacro(use_cxx11)
+ 
+-use_cxx11()
+-
+ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+     #required by butil/crc32.cc to boost performance for 10x
+     if((CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)") AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4))
+@@ -156,6 +154,50 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+ endif()
+ 
+ find_package(Protobuf REQUIRED)
++if(Protobuf_VERSION GREATER_EQUAL 4.22)
++    # required by absl
++    set(CMAKE_CXX_STANDARD 17)
++
++    find_package(absl REQUIRED CONFIG)
++    set(protobuf_ABSL_USED_TARGETS
++        absl::absl_check
++        absl::absl_log
++        absl::algorithm
++        absl::base
++        absl::bind_front
++        absl::bits
++        absl::btree
++        absl::cleanup
++        absl::cord
++        absl::core_headers
++        absl::debugging
++        absl::die_if_null
++        absl::dynamic_annotations
++        absl::flags
++        absl::flat_hash_map
++        absl::flat_hash_set
++        absl::function_ref
++        absl::hash
++        absl::layout
++        absl::log_initialize
++        absl::log_severity
++        absl::memory
++        absl::node_hash_map
++        absl::node_hash_set
++        absl::optional
++        absl::span
++        absl::status
++        absl::statusor
++        absl::strings
++        absl::synchronization
++        absl::time
++        absl::type_traits
++        absl::utility
++        absl::variant
++    )
++else()
++    use_cxx11()
++endif()
+ find_package(Threads REQUIRED)
+ 
+ find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
+@@ -229,7 +271,7 @@ include_directories(
+ 
+ set(DYNAMIC_LIB
+     ${GFLAGS_LIBRARY}
+-    ${PROTOBUF_LIBRARIES}
++    ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS}
+     ${LEVELDB_LIB}
+     ${PROTOC_LIB}
+     ${CMAKE_THREAD_LIBS_INIT}
+diff --git a/src/brpc/esp_message.h b/src/brpc/esp_message.h
+index 279f7b6a08..aecc837cb8 100644
+--- a/src/brpc/esp_message.h
++++ b/src/brpc/esp_message.h
+@@ -72,7 +72,7 @@ class EspMessage : public ::google::protobuf::Message {
+             ::google::protobuf::io::CodedOutputStream* output) const PB_310_OVERRIDE;
+     ::google::protobuf::uint8* SerializeWithCachedSizesToArray(
+             ::google::protobuf::uint8* output) const PB_310_OVERRIDE;
+-    int GetCachedSize() const override { return ByteSize(); }
++    int GetCachedSize() const PB_422_OVERRIDE { return ByteSize(); }
+ 
+ protected:
+     ::google::protobuf::Metadata GetMetadata() const override;
+diff --git a/src/brpc/global.cpp b/src/brpc/global.cpp
+index fbd669e774..1cce718342 100644
+--- a/src/brpc/global.cpp
++++ b/src/brpc/global.cpp
+@@ -292,6 +292,7 @@ static void* GlobalUpdate(void*) {
+     return NULL;
+ }
+ 
++#if GOOGLE_PROTOBUF_VERSION < 3022000
+ static void BaiduStreamingLogHandler(google::protobuf::LogLevel level,
+                                      const char* filename, int line,
+                                      const std::string& message) {
+@@ -311,6 +312,7 @@ static void BaiduStreamingLogHandler(google::protobuf::LogLevel level,
+     }
+     CHECK(false) << filename << ':' << line << ' ' << message;
+ }
++#endif
+ 
+ static void GlobalInitializeOrDieImpl() {
+     //////////////////////////////////////////////////////////////////
+@@ -326,8 +328,10 @@ static void GlobalInitializeOrDieImpl() {
+         CHECK(SIG_ERR != signal(SIGPIPE, SIG_IGN));
+     }
+ 
++#if GOOGLE_PROTOBUF_VERSION < 3022000
+     // Make GOOGLE_LOG print to comlog device
+     SetLogHandler(&BaiduStreamingLogHandler);
++#endif
+ 
+     // Setting the variable here does not work, the profiler probably check
+     // the variable before main() for only once.
+diff --git a/src/brpc/memcache.h b/src/brpc/memcache.h
+index c6fd2b95f4..014f075b4d 100644
+--- a/src/brpc/memcache.h
++++ b/src/brpc/memcache.h
+@@ -107,7 +107,7 @@ class MemcacheRequest : public ::google::protobuf::Message {
+     void SerializeWithCachedSizes(
+         ::google::protobuf::io::CodedOutputStream* output) const PB_310_OVERRIDE;
+     ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const PB_310_OVERRIDE;
+-    int GetCachedSize() const override { return _cached_size_; }
++    int GetCachedSize() const PB_422_OVERRIDE { return _cached_size_; }
+     
+     static const ::google::protobuf::Descriptor* descriptor();
+ 
+@@ -125,7 +125,7 @@ class MemcacheRequest : public ::google::protobuf::Message {
+ 
+     void SharedCtor();
+     void SharedDtor();
+-    void SetCachedSize(int size) const override;
++    void SetCachedSize(int size) const PB_422_OVERRIDE;
+ 
+     int _pipelined_count;
+     butil::IOBuf _buf;
+@@ -220,7 +220,7 @@ class MemcacheResponse : public ::google::protobuf::Message {
+     void SerializeWithCachedSizes(
+         ::google::protobuf::io::CodedOutputStream* output) const PB_310_OVERRIDE;
+     ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const PB_310_OVERRIDE;
+-    int GetCachedSize() const override { return _cached_size_; }
++    int GetCachedSize() const PB_422_OVERRIDE { return _cached_size_; }
+ 
+     static const ::google::protobuf::Descriptor* descriptor();
+ 
+@@ -233,7 +233,7 @@ class MemcacheResponse : public ::google::protobuf::Message {
+ 
+     void SharedCtor();
+     void SharedDtor();
+-    void SetCachedSize(int size) const override;
++    void SetCachedSize(int size) const PB_422_OVERRIDE;
+ 
+     std::string _err;
+     butil::IOBuf _buf;
+diff --git a/src/brpc/nshead_message.h b/src/brpc/nshead_message.h
+index 11cc1c60da..6cd06caf0b 100644
+--- a/src/brpc/nshead_message.h
++++ b/src/brpc/nshead_message.h
+@@ -67,7 +67,7 @@ class NsheadMessage : public ::google::protobuf::Message {
+     void SerializeWithCachedSizes(
+         ::google::protobuf::io::CodedOutputStream* output) const PB_310_OVERRIDE;
+     ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const PB_310_OVERRIDE;
+-    int GetCachedSize() const override { return ByteSize(); }
++    int GetCachedSize() const PB_422_OVERRIDE { return ByteSize(); }
+ 
+ protected:
+     ::google::protobuf::Metadata GetMetadata() const override;
+diff --git a/src/brpc/pb_compat.h b/src/brpc/pb_compat.h
+index 70faeb5424..d089530fa0 100644
+--- a/src/brpc/pb_compat.h
++++ b/src/brpc/pb_compat.h
+@@ -19,6 +19,12 @@
+ #ifndef BRPC_PB_COMPAT_H
+ #define BRPC_PB_COMPAT_H
+ 
++#if GOOGLE_PROTOBUF_VERSION < 4022000
++# define PB_422_OVERRIDE override
++#else
++# define PB_422_OVERRIDE
++#endif
++
+ #if GOOGLE_PROTOBUF_VERSION < 3021000
+ # define PB_321_OVERRIDE override
+ #else
+diff --git a/src/brpc/redis.h b/src/brpc/redis.h
+index d02e894121..6b949ea46a 100644
+--- a/src/brpc/redis.h
++++ b/src/brpc/redis.h
+@@ -125,7 +125,7 @@ class RedisRequest : public ::google::protobuf::Message {
+     void SerializeWithCachedSizes(
+         ::google::protobuf::io::CodedOutputStream* output) const PB_310_OVERRIDE;
+     ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const PB_310_OVERRIDE;
+-    int GetCachedSize() const override { return _cached_size_; }
++    int GetCachedSize() const PB_422_OVERRIDE { return _cached_size_; }
+ 
+     static const ::google::protobuf::Descriptor* descriptor();
+     
+@@ -137,7 +137,7 @@ class RedisRequest : public ::google::protobuf::Message {
+ private:
+     void SharedCtor();
+     void SharedDtor();
+-    void SetCachedSize(int size) const override;
++    void SetCachedSize(int size) const PB_422_OVERRIDE;
+     bool AddCommandWithArgs(const char* fmt, ...);
+ 
+     int _ncommand;    // # of valid commands
+@@ -198,7 +198,7 @@ class RedisResponse : public ::google::protobuf::Message {
+     void SerializeWithCachedSizes(
+         ::google::protobuf::io::CodedOutputStream* output) const PB_310_OVERRIDE;
+     ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const PB_310_OVERRIDE;
+-    int GetCachedSize() const override { return _cached_size_; }
++    int GetCachedSize() const PB_422_OVERRIDE { return _cached_size_; }
+ 
+     static const ::google::protobuf::Descriptor* descriptor();
+ 
+@@ -208,7 +208,7 @@ class RedisResponse : public ::google::protobuf::Message {
+ private:
+     void SharedCtor();
+     void SharedDtor();
+-    void SetCachedSize(int size) const override;
++    void SetCachedSize(int size) const PB_422_OVERRIDE;
+ 
+     RedisReply _first_reply;
+     RedisReply* _other_replies;
+diff --git a/src/brpc/serialized_request.h b/src/brpc/serialized_request.h
+index 0fbf76bad4..5b68262e14 100644
+--- a/src/brpc/serialized_request.h
++++ b/src/brpc/serialized_request.h
+@@ -53,7 +53,7 @@ class SerializedRequest : public ::google::protobuf::Message {
+     void Clear() override;
+     bool IsInitialized() const override;
+     int ByteSize() const;
+-    int GetCachedSize() const override { return (int)_serialized.size(); }
++    int GetCachedSize() const PB_422_OVERRIDE { return (int)_serialized.size(); }
+     butil::IOBuf& serialized_data() { return _serialized; }
+     const butil::IOBuf& serialized_data() const { return _serialized; }
+ 
+@@ -71,7 +71,7 @@ class SerializedRequest : public ::google::protobuf::Message {
+     void MergeFrom(const SerializedRequest& from);
+     void SharedCtor();
+     void SharedDtor();
+-    void SetCachedSize(int size) const override;
++    void SetCachedSize(int size) const PB_422_OVERRIDE;
+   
+ private:
+     butil::IOBuf _serialized;
+diff --git a/src/json2pb/json_to_pb.cpp b/src/json2pb/json_to_pb.cpp
+index 6a6f46cc91..2652d6d487 100644
+--- a/src/json2pb/json_to_pb.cpp
++++ b/src/json2pb/json_to_pb.cpp
+@@ -534,8 +534,12 @@ bool JsonValueToProtoMessage(const BUTIL_RAPIDJSON_NAMESPACE::Value& json_value,
+     for (int i = 0; i < descriptor->extension_range_count(); ++i) {
+         const google::protobuf::Descriptor::ExtensionRange*
+             ext_range = descriptor->extension_range(i);
+-        for (int tag_number = ext_range->start; tag_number < ext_range->end;
+-             ++tag_number) {
++#if GOOGLE_PROTOBUF_VERSION < 4022000
++        for (int tag_number = ext_range->start; tag_number < ext_range->end; ++tag_number)
++#else
++        for (int tag_number = ext_range->start_number(); tag_number < ext_range->end_number(); ++tag_number)
++#endif
++        {
+             const google::protobuf::FieldDescriptor* field =
+                 reflection->FindKnownExtensionByNumber(tag_number);
+             if (field) {
+diff --git a/src/json2pb/pb_to_json.cpp b/src/json2pb/pb_to_json.cpp
+index c6ce183af3..a299e42462 100644
+--- a/src/json2pb/pb_to_json.cpp
++++ b/src/json2pb/pb_to_json.cpp
+@@ -75,8 +75,12 @@ bool PbToJsonConverter::Convert(const google::protobuf::Message& message, Handle
+     for (int i = 0; i < ext_range_count; ++i) {
+         const google::protobuf::Descriptor::ExtensionRange*
+             ext_range = descriptor->extension_range(i);
+-        for (int tag_number = ext_range->start;
+-             tag_number < ext_range->end; ++tag_number) {
++#if GOOGLE_PROTOBUF_VERSION < 4022000
++        for (int tag_number = ext_range->start; tag_number < ext_range->end; ++tag_number)
++#else
++        for (int tag_number = ext_range->start_number(); tag_number < ext_range->end_number(); ++tag_number)
++#endif
++        {
+             const google::protobuf::FieldDescriptor* field =
+                     reflection->FindKnownExtensionByNumber(tag_number);
+             if (field) {
+diff --git a/src/brpc/protocol.cpp b/src/brpc/protocol.cpp
+index 5f39939d..ce174c2d 100644
+--- a/src/brpc/protocol.cpp
++++ b/src/brpc/protocol.cpp
+@@ -18,13 +18,11 @@
+ 
+ // Since kDefaultTotalBytesLimit is private, we need some hacks to get the limit.
+ // Works for pb 2.4, 2.6, 3.0
+-#define private public
+-#include <google/protobuf/io/coded_stream.h>
+-const int PB_TOTAL_BYETS_LIMITS_RAW =
+-    google::protobuf::io::CodedInputStream::kDefaultTotalBytesLimit;
++#include <climits>
++#include <cstdint>
++const int PB_TOTAL_BYETS_LIMITS_RAW = INT_MAX;
+ const uint64_t PB_TOTAL_BYETS_LIMITS =
+     PB_TOTAL_BYETS_LIMITS_RAW < 0 ? (uint64_t)-1LL : PB_TOTAL_BYETS_LIMITS_RAW;
+-#undef private
+ 
+ #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+ #include <google/protobuf/text_format.h>

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -90,6 +90,7 @@ def _com_github_brpc_brpc():
         patches = [
             "@yacl//bazel:patches/brpc.patch",
             "@yacl//bazel:patches/brpc_m1.patch",
+            "@yacl//bazel:patches/brpc_pb.patch",
         ],
         urls = [
             "https://github.com/apache/brpc/archive/refs/tags/1.8.0.tar.gz",

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -142,11 +142,11 @@ def _com_google_protobuf():
     maybe(
         http_archive,
         name = "com_google_protobuf",
-        sha256 = "ba0650be1b169d24908eeddbe6107f011d8df0da5b1a5a4449a913b10e578faf",
-        strip_prefix = "protobuf-3.19.4",
+        sha256 = "7beed9c511d632cff7c22ac0094dd7720e550153039d5da7e059bcceb488474a",
+        strip_prefix = "protobuf-25.0",
         type = "tar.gz",
         urls = [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protobuf-all-3.19.4.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v25.0/protobuf-25.0.tar.gz",
         ],
     )
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -143,11 +143,11 @@ def _com_google_protobuf():
     maybe(
         http_archive,
         name = "com_google_protobuf",
-        sha256 = "7beed9c511d632cff7c22ac0094dd7720e550153039d5da7e059bcceb488474a",
-        strip_prefix = "protobuf-25.0",
+        sha256 = "2c6a36c7b5a55accae063667ef3c55f2642e67476d96d355ff0acb13dbb47f09",
+        strip_prefix = "protobuf-21.12",
         type = "tar.gz",
         urls = [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v25.0/protobuf-25.0.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protobuf-all-21.12.tar.gz",
         ],
     )
 


### PR DESCRIPTION
* Pb 20+ is no longer fully compatible with <= 3.19
* Libraries like TensorFlow now requires 20+
* 21 is the greatest version we can use at this point. (openxla requires something removed in 22+)