### PR TITLE
fix: missing g++ in prerequisites

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -8,7 +8,7 @@ To build Yacl from source, you will need the following tools:
 
 - [bazel](https://bazel.build/): We recommend to use the official [bazelisk](https://github.com/bazelbuild/bazelisk?tab=readme-ov-file#installation) to manage bazel version.
   - If not use bazelisk, please set the environment variable `USE_BAZEL_VERSION` to the specified version, which can be found in the `.bazeliskrc` file.
-- [gcc >= 10.3](https://gcc.gnu.org/)
+- [gcc >= 10.3, g++ >= 10.3](https://gcc.gnu.org/)
 - [cmake](https://cmake.org/)
 - [ninja/ninja-build](https://ninja-build.org/)
 - **Perl 5 with core modules** (Required by [OpenSSL](https://github.com/openssl/openssl/blob/master/INSTALL.md#prerequisites))
@@ -28,7 +28,7 @@ The building process of YACL is as following.
 Download the dependencies
 
 ```sh
-$ sudo apt install gcc wget cmake ninja-build nasm automake libtool libomp-dev
+$ sudo apt install gcc g++ wget cmake ninja-build nasm automake libtool libomp-dev
 ```
 
 We recommend to use `bazelisk` to manage different versions of `bazel`. On Linux, You can download Bazelisk binary on our Releases page and add it to your PATH manually, which also works on macOS and Windows. You can download the newest `bazelisk` binary from its official [github release page](https://github.com/bazelbuild/bazelisk/releases).

--- a/docs/locale/zh_CN/LC_MESSAGES/src/getting_started.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/src/getting_started.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YACL \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-11 10:28+0800\n"
+"POT-Creation-Date: 2025-03-11 11:30+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_CN\n"
@@ -50,7 +50,7 @@ msgid ""
 msgstr ""
 
 #: ../../../GETTING_STARTED.md:11
-msgid "[gcc >= 10.3](https://gcc.gnu.org/)"
+msgid "[gcc >= 10.3, g++ >= 10.3](https://gcc.gnu.org/)"
 msgstr ""
 
 #: ../../../GETTING_STARTED.md:12
@@ -169,4 +169,7 @@ msgid ""
 "[cpplint](https://marketplace.visualstudio.com/items?itemName=mine.cpplint):"
 " code style check tool extension for cpplint (requires `cpplint` binary)"
 msgstr ""
+
+#~ msgid "[gcc >= 10.3](https://gcc.gnu.org/)"
+#~ msgstr ""
 


### PR DESCRIPTION
Fixed #481 

add g++ as a prerequisite in [GETTING_STARTED.md](https://github.com/secretflow/yacl/compare/main...yangjucai:yacl:main#diff-d0243df16bd9ebcc544cb26394cf6ec5cc2be67bdca0a44c51457c0baf94b1c8) line13 & line31, [getting_started.po](https://github.com/secretflow/yacl/commit/e99a4766d4455485446c4f8b8f134151eb9a2775) line53.