### PR TITLE
Fix: Add implementation of TCCR hash function for malicious security

### DIFF
--- a/yacl/crypto/tools/benchmark.cc
+++ b/yacl/crypto/tools/benchmark.cc
@@ -26,7 +26,7 @@ void BM_DefaultArguments(benchmark::internal::Benchmark* b) {
       ->Arg(16777216);  // 2^24
 }
 
-// Register benchmarks for (Circular) CrHash
+// Register benchmarks for (Tweakable) (Circular) CrHash
 BENCHMARK_REGISTER_F(TheoreticalToolBench, RO)->Apply(BM_DefaultArguments);
 BENCHMARK_REGISTER_F(TheoreticalToolBench, RP)->Apply(BM_DefaultArguments);
 BENCHMARK_REGISTER_F(TheoreticalToolBench, CRHASH)->Apply(BM_DefaultArguments);
@@ -34,6 +34,9 @@ BENCHMARK_REGISTER_F(TheoreticalToolBench, CRHASH_INPLACE)
     ->Apply(BM_DefaultArguments);
 BENCHMARK_REGISTER_F(TheoreticalToolBench, CCRHASH)->Apply(BM_DefaultArguments);
 BENCHMARK_REGISTER_F(TheoreticalToolBench, CCRHASH_INPLACE)
+    ->Apply(BM_DefaultArguments);
+BENCHMARK_REGISTER_F(TheoreticalToolBench, TCCRHASH)->Apply(BM_DefaultArguments);
+BENCHMARK_REGISTER_F(TheoreticalToolBench, TCCRHASH_INPLACE)
     ->Apply(BM_DefaultArguments);
 
 BENCHMARK_REGISTER_F(PrgBench, PrgAesEcb)->Apply(BM_DefaultArguments);

--- a/yacl/crypto/tools/benchmark.h
+++ b/yacl/crypto/tools/benchmark.h
@@ -121,6 +121,33 @@ BENCHMARK_DEFINE_F(TheoreticalToolBench, CCRHASH_INPLACE)
   }
 }
 
+BENCHMARK_DEFINE_F(TheoreticalToolBench, TCCRHASH)(benchmark::State& state) {
+  std::vector<uint128_t> input;
+  for (auto _ : state) {
+    state.PauseTiming();
+    size_t n = state.range(0);
+    input.resize(n);
+    std::fill(input.begin(), input.end(), 0);
+
+    state.ResumeTiming();
+    ParaTccrHash_128(absl::MakeSpan(input), 0);
+  }
+}
+
+BENCHMARK_DEFINE_F(TheoreticalToolBench, TCCRHASH_INPLACE)
+(benchmark::State& state) {
+  std::vector<uint128_t> input;
+  for (auto _ : state) {
+    state.PauseTiming();
+    size_t n = state.range(0);
+    input.resize(n);
+    std::fill(input.begin(), input.end(), 0);
+
+    state.ResumeTiming();
+    ParaTccrHashInplace_128(absl::MakeSpan(input), 0);
+  }
+}
+
 // 1st arg = numer of desired outputs
 BENCHMARK_DEFINE_F(PrgBench, PrgAesEcb)
 (benchmark::State& state) {

--- a/yacl/crypto/tools/crhash.cc
+++ b/yacl/crypto/tools/crhash.cc
@@ -148,4 +148,73 @@ void ParaCcrHashInplace_128(absl::Span<uint128_t> inout) {
   ParaCrHashInplace_128(inout_span.subspan(offset, remain));
 }
 
+// Tweakable Circular Correlation Robust (TCCR) Hash function 
+// See GKWY20 paper (https://eprint.iacr.org/2019/074.pdf) Sec 7.4
+// TccrHash(x,i) = RP(RP(x) ^ i) ^ RP(x)
+uint128_t TccrHash_128(uint128_t x, uint128_t i) {
+    const auto& RP = GetCrHashDefaultRP();  // RP为ECB模式的AES
+    uint128_t tmp = RP.Gen(x);  // tmp = RP(x)
+    return RP.Gen(tmp ^ i) ^ tmp;
+}
+
+// TccrHash(x,i) for elements in x, i begins with begin_index, return the result
+std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x, uint128_t begin_index) {
+    std::vector<uint128_t> out(x.size());
+    std::vector<uint128_t> tmp(x.size());
+    const auto& RP = GetCrHashDefaultRP();  // RP为ECB模式的AES
+    // out = RP(x)
+    RP.GenForMultiInputs(x, absl::MakeSpan(out));  
+    // tmp = RP(x)
+    std::memcpy(tmp.data(), out.data(), x.size() * sizeof(uint128_t));
+    // tmp = RP(x) ^ i
+    for(uint128_t i = 0; i < tmp.size(); i++) 
+        tmp[i] = tmp[i] ^ (i + begin_index);
+    // tmp = RP(tmp) = RP(RP(x) ^ i)
+    RP.GenForMultiInputsInplace(absl::MakeSpan(tmp));
+    // out = tmp ^ out = RP(RP(x) ^ i) ^ RP(x)
+    std::transform(tmp.begin(), tmp.end(), out.begin(), out.begin(),
+                   std::bit_xor<uint128_t>());
+    return out;
+}
+
+// TccrHash(x,i) for elements in inout (inplace), i begins with begin_index
+void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint128_t begin_index) {
+  const auto& RP = GetCrHashDefaultRP();  
+  // TODO: add dynamic batch size
+  alignas(32) std::array<uint128_t, kBatchSize> tmp;  
+  auto tmp_span = absl::MakeSpan(tmp);
+  const uint64_t size = inout.size();
+  uint128_t i;
+
+  uint64_t offset = 0;
+  for (; offset + kBatchSize <= size; offset += kBatchSize) {
+    auto inout_span = inout.subspan(offset, kBatchSize);
+    // inout_span = RP(x)
+    RP.GenForMultiInputsInplace(inout_span);
+    // tmp_span = RP(x)
+    std::memcpy(tmp_span.data(), inout_span.data(), kBatchSize * sizeof(uint128_t));
+    // tmp_span = RP(x) ^ i
+    for(i = offset; i < offset + tmp_span.size(); i++) 
+        tmp_span[i] = tmp_span[i] ^ (i + begin_index);  
+    // tmp_span = RP(RP(x) ^ i)
+    RP.GenForMultiInputsInplace(tmp_span);
+    // inout_span = tmp_span ^ inout_span = RP(RP(x) ^ i) ^ RP(x)
+    std::transform(tmp_span.begin(), tmp_span.begin() + kBatchSize,
+                   inout_span.begin(), inout_span.begin(),
+                   std::bit_xor<uint128_t>());
+  }
+  uint64_t remain = size - offset;
+  if (remain > 0) {
+      auto inout_span = inout.subspan(offset, remain);
+      RP.GenForMultiInputsInplace(inout_span);
+      std::memcpy(tmp_span.data(), inout_span.data(), remain * sizeof(uint128_t));
+      for(i = offset; i < offset + remain; i++) 
+          tmp_span[i] = tmp_span[i] ^ (i + begin_index);  
+      RP.GenForMultiInputsInplace(tmp_span.subspan(0, remain));
+      std::transform(tmp_span.begin(), tmp_span.begin() + remain,
+                     inout_span.begin(), inout_span.begin(),
+                     std::bit_xor<uint128_t>());
+  }  
+}
+
 }  // namespace yacl::crypto

--- a/yacl/crypto/tools/crhash.h
+++ b/yacl/crypto/tools/crhash.h
@@ -48,7 +48,15 @@ std::vector<uint128_t> ParaCcrHash_128(absl::Span<const uint128_t> x);
 // inplace parallel ccrhash for many blocks
 void ParaCcrHashInplace_128(absl::Span<uint128_t> inout);
 
-// TODO(@shanzhu) Tweakable Correlation Robust Hash function (Multiple Blocks)
-// See https://eprint.iacr.org/2019/074.pdf Sec 7.4
+// Tweakable Circular Correlation Robust (TCCR) Hash function 
+// See GKWY20 paper (https://eprint.iacr.org/2019/074.pdf) Sec 7.4
+// tccrhash for a single block, TccrHash(x,i) = RP(RP(x) ^ i) ^ RP(x)
+uint128_t TccrHash_128(uint128_t x, uint128_t i);
+
+// parallel tccrhash for multiple blocks
+std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x, uint128_t begin_index);
+
+// inplace parallel tccrhash for many blocks
+void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint128_t begin_index);
 
 }  // namespace yacl::crypto

--- a/yacl/crypto/tools/crhash_test.cc
+++ b/yacl/crypto/tools/crhash_test.cc
@@ -108,4 +108,46 @@ TEST(RPTest, ParaCcrHashInplaceWorks) {
   EXPECT_EQ(absl::MakeSpan(inout), absl::MakeSpan(inout_copy));
 }
 
+TEST(RPTest, TccrHashWorks) {
+  uint128_t x = FastRandU128();
+  uint128_t y = FastRandU128();
+  uint128_t id1 = FastRandU128();
+  uint128_t id2 = FastRandU128();
+
+  EXPECT_NE(x, y);
+  EXPECT_NE(id1, id2);
+  EXPECT_NE(TccrHash_128(x, id1), 0);  
+  EXPECT_EQ(TccrHash_128(x, id1), TccrHash_128(x, id1));
+  EXPECT_NE(TccrHash_128(x, id1), TccrHash_128(y, id1));
+  /* when id1 != id2, expect Hash(x, id1) != Hash(x, id2) */
+  EXPECT_NE(TccrHash_128(x, id1), TccrHash_128(x, id2));  
+}
+
+TEST(RPTest, ParaTccrHashWorks) {
+  const auto size = 20;
+
+  std::vector<uint128_t> zeros(size, 0);
+  auto input = RandomBlocks(size);
+  auto output = ParaTccrHash_128(absl::MakeSpan(input), 0);
+
+  EXPECT_NE(absl::MakeSpan(output), absl::MakeSpan(zeros));
+  EXPECT_NE(absl::MakeSpan(output), absl::MakeSpan(input));
+  EXPECT_EQ(absl::MakeSpan(output), ParaTccrHash_128(absl::MakeSpan(input), 0));
+}
+
+TEST(RPTest, ParaTccrHashInplaceWorks) {
+  const auto size = 20;
+
+  std::vector<uint128_t> zeros(size, 0);
+  auto inout = RandomBlocks(size);
+  auto inout_copy = inout;
+
+  ParaTccrHashInplace_128(absl::MakeSpan(inout), 0);
+  EXPECT_NE(absl::MakeSpan(inout), absl::MakeSpan(zeros));
+  EXPECT_NE(absl::MakeSpan(inout), absl::MakeSpan(inout_copy));
+
+  ParaTccrHashInplace_128(absl::MakeSpan(inout_copy), 0);
+  EXPECT_EQ(absl::MakeSpan(inout), absl::MakeSpan(inout_copy));
+}
+
 }  // namespace yacl::crypto

--- a/yacl/kernel/algorithms/kos_ote.cc
+++ b/yacl/kernel/algorithms/kos_ote.cc
@@ -207,8 +207,8 @@ void KosOtExtSend(const std::shared_ptr<link::Context>& ctx,
   auto batch1 = VecXorMonochrome(absl::MakeSpan(q_ext), delta);
 
   if (!cot) {
-    ParaCrHashInplace_128(absl::MakeSpan(batch0));
-    ParaCrHashInplace_128(absl::MakeSpan(batch1));
+    ParaTccrHashInplace_128(absl::MakeSpan(batch0), 0);
+    ParaTccrHashInplace_128(absl::MakeSpan(batch1), 0);
   }
 
   for (size_t i = 0; i < ot_num_valid; i++) {
@@ -303,7 +303,7 @@ void KosOtExtRecv(const std::shared_ptr<link::Context>& ctx,
 
   t_ext.resize(ot_num_valid);
   if (!cot) {
-    ParaCrHashInplace_128(absl::MakeSpan(t_ext));
+    ParaTccrHashInplace_128(absl::MakeSpan(t_ext), 0);
   }
   for (size_t i = 0; i < ot_num_valid; i++) {
     recv_blocks[i] = t_ext[i];

--- a/yacl/kernel/algorithms/mpfss.cc
+++ b/yacl/kernel/algorithms/mpfss.cc
@@ -64,7 +64,13 @@ void MpfssSend(const std::shared_ptr<link::Context>& ctx,
 
     GywzOtExtSend(ctx, ot_slice, this_size, this_span);
     // Break the correlation
-    ParaCrHashInplace_128(this_span);
+    // use TCCR hash for malicious security, or CR for semi-honest
+    if (param.is_mal_) {
+    	ParaTccrHashInplace_128(this_span, i * batch_size);
+	}
+	else {
+		ParaCrHashInplace_128(this_span);
+	}
     send_msgs[i] =
         std::reduce(this_span.begin(), this_span.end(), send_msgs[i], op.add);
   }
@@ -101,7 +107,13 @@ void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
         i * math::Log2Ceil(batch_size),
         i * math::Log2Ceil(batch_size) + math::Log2Ceil(this_size));
     GywzOtExtRecv(ctx, ot_slice, this_size, indexes[i], this_span);
-    ParaCrHashInplace_128(this_span);
+    // use TCCR hash for malicious security, or CR for semi-honest
+    if (param.is_mal_) {
+    	ParaTccrHashInplace_128(this_span, i * batch_size);
+	}
+	else {
+		ParaCrHashInplace_128(this_span);
+	}
     dpf_sum[i] =
         std::reduce(this_span.begin(), this_span.end(), dpf_sum[i], op.add);
   }
@@ -157,7 +169,13 @@ void MpfssSend(const std::shared_ptr<link::Context>& ctx,
         i * math::Log2Ceil(batch_size) + math::Log2Ceil(this_size));
 
     GywzOtExtSend(ctx, ot_slice, this_size, this_span);
-    ParaCrHashInplace_128(this_span);
+    // use TCCR hash for malicious security, or CR for semi-honest
+    if (param.is_mal_) {
+    	ParaTccrHashInplace_128(this_span, i * batch_size);
+	}
+	else {
+		ParaCrHashInplace_128(this_span);
+	}
 
     // Break the correlation
     std::transform(
@@ -206,7 +224,13 @@ void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
         i * math::Log2Ceil(batch_size),
         i * math::Log2Ceil(batch_size) + math::Log2Ceil(this_size));
     GywzOtExtRecv(ctx, ot_slice, this_size, indexes[i], this_span);
-    ParaCrHashInplace_128(this_span);
+    // use TCCR hash for malicious security, or CR for semi-honest
+    if (param.is_mal_) {
+    	ParaTccrHashInplace_128(this_span, i * batch_size);
+	}
+	else {
+		ParaCrHashInplace_128(this_span);
+	}
 
     std::transform(
         this_span.begin(), this_span.end(), output.data() + i * batch_size,
@@ -284,7 +308,13 @@ void MpfssSend_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // GywzOtExt is single-point COT
       GywzOtExtSend_fixed_index(ot_slice, this_size, this_span, send_span);
       // Use CrHash to break the correlation
-      ParaCrHashInplace_128(this_span);
+      // use TCCR hash for malicious security, or CR for semi-honest
+      if (param.is_mal_) {
+    	  ParaTccrHashInplace_128(this_span, batch_idx * batch_length);
+	  }
+	  else {
+		  ParaCrHashInplace_128(this_span);
+	  }  
       // this_span xor
       dpf_sum[batch_idx] = std::reduce(this_span.begin(), this_span.end(),
                                        dpf_sum[batch_idx], op.add);
@@ -372,7 +402,13 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // GywzOtExt is single-point COT
       GywzOtExtRecv_fixed_index(ot_slice, this_size, this_span, recv_span);
       // Use CrHash to break the correlation
-      ParaCrHashInplace_128(this_span);
+      // use TCCR hash for malicious security, or CR for semi-honest
+      if (param.is_mal_) {
+    	  ParaTccrHashInplace_128(this_span, batch_idx * batch_length);
+	  }
+	  else {
+		  ParaCrHashInplace_128(this_span);
+	  }  
       // this_span xor
       dpf_sum[batch_idx] = std::reduce(this_span.begin(), this_span.end(),
                                        dpf_sum[batch_idx], op.add);
@@ -455,7 +491,13 @@ void MpfssSend_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // GywzOtExt is single-point COT
       GywzOtExtSend_fixed_index(ot_slice, full_size, this_span, send_span);
       // Use CrHash to break the correlation
-      ParaCrHashInplace_128(this_span.subspan(0, this_size));
+      // use TCCR hash for malicious security, or CR for semi-honest
+      if (param.is_mal_) {
+    	  ParaTccrHashInplace_128(this_span.subspan(0, this_size), 0);
+	  }
+	  else {
+	  	  ParaCrHashInplace_128(this_span.subspan(0, this_size));
+	  }
       // convert to uint64_t
       std::transform(this_span.begin(), this_span.begin() + this_size,
                      output.data() + batch_idx * batch_size,
@@ -560,7 +602,13 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // GywzOtExt is single-point COT
       GywzOtExtRecv_fixed_index(ot_slice, full_size, this_span, recv_span);
       // Use CrHash to break the correlation
-      ParaCrHashInplace_128(this_span.subspan(0, this_size));
+      // use TCCR hash for malicious security, or CR for semi-honest
+      if (param.is_mal_) {
+    	  ParaTccrHashInplace_128(this_span.subspan(0, this_size), 0);
+	  }
+	  else {
+	  	  ParaCrHashInplace_128(this_span.subspan(0, this_size));
+	  }
       // convert to uint64_t
       std::transform(this_span.begin(), this_span.begin() + this_size,
                      output.data() + batch_idx * batch_size,

--- a/yacl/kernel/algorithms/mpfss.h
+++ b/yacl/kernel/algorithms/mpfss.h
@@ -53,7 +53,7 @@ struct MpFssParam {
   LpnNoiseAsm assumption_ = LpnNoiseAsm::RegularNoise;
   std::vector<uint32_t> indexes_ = std::vector<uint32_t>(0);  // size zero
 
-  bool is_mal_{false};
+  bool is_mal_ = false;
 
   MpFssParam() : MpFssParam(1, 2, LpnNoiseAsm::RegularNoise, false) {}
 

--- a/yacl/kernel/algorithms/softspoken_ote.cc
+++ b/yacl/kernel/algorithms/softspoken_ote.cc
@@ -669,8 +669,15 @@ void SoftspokenOtExtSender::Send(
       XorBlock(absl::MakeSpan(V[s]), absl::MakeSpan(V_xor_delta[s]), delta);
       // 4. perform CrHash to break the correlation if cot flag is false
       if (!cot) {
-        ParaCrHashInplace_128(absl::MakeSpan(V[s]));
-        ParaCrHashInplace_128(absl::MakeSpan(V_xor_delta[s]));
+      	// use TCCR hash for malicious security, or CR for semi-honest
+      	if (mal_) {
+          ParaTccrHashInplace_128(absl::MakeSpan(V[s]), t * super_batch_size + s * kBatchSize);
+          ParaTccrHashInplace_128(absl::MakeSpan(V_xor_delta[s]), t * super_batch_size + s * kBatchSize);
+		} 
+		else {
+		  ParaCrHashInplace_128(absl::MakeSpan(V[s]));
+          ParaCrHashInplace_128(absl::MakeSpan(V_xor_delta[s]));
+		}
       }
 
       for (uint64_t j = 0; j < kBatchSize; ++j) {
@@ -703,8 +710,15 @@ void SoftspokenOtExtSender::Send(
       XorBlock(absl::MakeSpan(V[t]), absl::MakeSpan(V_xor_delta[t]), delta);
       // 4. perform CrHash to break the correlation if cot flag is false
       if (!cot) {
-        ParaCrHashInplace_128(absl::MakeSpan(V[t]));
-        ParaCrHashInplace_128(absl::MakeSpan(V_xor_delta[t]));
+      	// use TCCR hash for malicious security, or CR for semi-honest
+      	if (mal_) {
+      	  ParaTccrHashInplace_128(absl::MakeSpan(V[t]), batch_offset + t * kBatchSize);
+          ParaTccrHashInplace_128(absl::MakeSpan(V_xor_delta[t]), batch_offset + t * kBatchSize);	
+		}
+		else {
+		  ParaCrHashInplace_128(absl::MakeSpan(V[t]));
+          ParaCrHashInplace_128(absl::MakeSpan(V_xor_delta[t]));
+		}
       }
 
       const uint64_t limit =
@@ -928,7 +942,7 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
     }
   }
 
-  // deal with normal bathc
+  // deal with normal batch 
   for (uint64_t t = 0; t < batch_num; ++t) {
     // The same as IKNP OTe
     // 1. smallfield/subspace VOLE
@@ -1038,7 +1052,13 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
       MatrixTranspose128(&W[s]);
       // 4. perform CrHash to break the correlation if cot flag is false
       if (!cot) {
-        ParaCrHashInplace_128(absl::MakeSpan(W[s]));
+      	// use TCCR hash for malicious security, or CR for semi-honest
+      	if (mal_) {
+      	  ParaTccrHashInplace_128(absl::MakeSpan(W[s]), t * super_batch_size + s * batch_size);
+		}
+		else {
+		  ParaCrHashInplace_128(absl::MakeSpan(W[s]));
+		}
       }
       for (uint64_t j = 0; j < kBatchSize; ++j) {
         recv_blocks[t * super_batch_size + s * batch_size + j] = W[s][j];
@@ -1046,7 +1066,7 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
     }
   }
 
-  // deal with normal bathc
+  // deal with normal batch
   for (uint64_t t = 0; t < batch_num; ++t) {
     // The same as IKNP OTe
     // 1. smallfield/subspace VOLE
@@ -1068,7 +1088,13 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
           std::min(kBatchSize, numOt - batch_offset - t * kBatchSize);
       // 4. perform CrHash to break the correlation if cot flag is false
       if (!cot) {
-        ParaCrHashInplace_128(absl::MakeSpan(W[t]));
+      	// use TCCR hash for malicious security, or CR for semi-honest
+      	if (mal_) {
+      	  ParaTccrHashInplace_128(absl::MakeSpan(W[t]), batch_offset + t * kBatchSize);
+		} 
+		else {
+		  ParaCrHashInplace_128(absl::MakeSpan(W[t]));
+		}
       }
       for (uint64_t j = 0; j < limit; ++j) {
         recv_blocks[batch_offset + t * kBatchSize + j] = W[t][j];

--- a/yacl/kernel/ot_kernel.cc
+++ b/yacl/kernel/ot_kernel.cc
@@ -42,7 +42,7 @@ using OtMsg = uint128_t;
 using OtMsgPair = std::array<OtMsg, 2>;
 using OtChoices = dynamic_bitset<uint128_t>;
 
-// Inplace-conversion from cot to rot
+// Inplace-conversion from cot to rot (sender function)
 void naive_cot2rot(const OtSendStore& cot_store, OtSendStore* rot_store) {
   YACL_ENFORCE(cot_store.Size() == rot_store->Size());     // size should match
   YACL_ENFORCE(cot_store.Type() == OtStoreType::Compact);  // compact mode
@@ -50,13 +50,13 @@ void naive_cot2rot(const OtSendStore& cot_store, OtSendStore* rot_store) {
   const uint32_t ot_num = cot_store.Size();  // warning: narrow conversion
   parallel_for(0, ot_num, 1, [&](uint64_t beg, uint64_t end) {
     for (uint64_t i = beg; i < end; ++i) {
-      rot_store->SetNormalBlock(i, 0, CrHash_128(cot_store.GetBlock(i, 0)));
-      rot_store->SetNormalBlock(i, 1, CrHash_128(cot_store.GetBlock(i, 1)));
+      rot_store->SetNormalBlock(i, 0, TccrHash_128(cot_store.GetBlock(i, 0), i));
+      rot_store->SetNormalBlock(i, 1, TccrHash_128(cot_store.GetBlock(i, 1), i));
     }
   });
 }
 
-// Inplace-conversion from cot to rot
+// Inplace-conversion from cot to rot (receiver function)
 void naive_cot2rot(const OtRecvStore& cot_store, OtRecvStore* rot_store) {
   const uint32_t ot_num = cot_store.Size();  // warning: narrow conversion
   YACL_ENFORCE(cot_store.Type() == OtStoreType::Compact);  // compact mode
@@ -66,7 +66,7 @@ void naive_cot2rot(const OtRecvStore& cot_store, OtRecvStore* rot_store) {
 
   parallel_for(0, ot_num, 1, [&](uint64_t beg, uint64_t end) {
     for (uint64_t i = beg; i < end; ++i) {
-      rot_store->SetBlock(i, CrHash_128(cot_store.GetBlock(i)));
+      rot_store->SetBlock(i, TccrHash_128(cot_store.GetBlock(i), i));
     }
   });
 }


### PR DESCRIPTION
In conversion from COT to ROT, the hash function used for breaking correlation must be Tweakable Correlation Robust (TCR) to ensure malicious security. In this fix, I implement the TCCR hash function according to GKWY20 paper Sec 7.4 (https://eprint.iacr.org/2019/074.pdf). TCCR functions are also TCR.