### PR TITLE
Fix: Add implementation of TCCR hash function for malicious security in OT conversion

### DIFF
--- a/yacl/crypto/tools/benchmark.cc
+++ b/yacl/crypto/tools/benchmark.cc
@@ -26,7 +26,7 @@ void BM_DefaultArguments(benchmark::internal::Benchmark* b) {
       ->Arg(16777216);  // 2^24
 }
 
-// Register benchmarks for (Circular) CrHash
+// Register benchmarks for (Tweakable) (Circular) CrHash
 BENCHMARK_REGISTER_F(TheoreticalToolBench, RO)->Apply(BM_DefaultArguments);
 BENCHMARK_REGISTER_F(TheoreticalToolBench, RP)->Apply(BM_DefaultArguments);
 BENCHMARK_REGISTER_F(TheoreticalToolBench, CRHASH)->Apply(BM_DefaultArguments);
@@ -34,6 +34,9 @@ BENCHMARK_REGISTER_F(TheoreticalToolBench, CRHASH_INPLACE)
     ->Apply(BM_DefaultArguments);
 BENCHMARK_REGISTER_F(TheoreticalToolBench, CCRHASH)->Apply(BM_DefaultArguments);
 BENCHMARK_REGISTER_F(TheoreticalToolBench, CCRHASH_INPLACE)
+    ->Apply(BM_DefaultArguments);
+BENCHMARK_REGISTER_F(TheoreticalToolBench, TCCRHASH)->Apply(BM_DefaultArguments);
+BENCHMARK_REGISTER_F(TheoreticalToolBench, TCCRHASH_INPLACE)
     ->Apply(BM_DefaultArguments);
 
 BENCHMARK_REGISTER_F(PrgBench, PrgAesEcb)->Apply(BM_DefaultArguments);

--- a/yacl/crypto/tools/benchmark.cc
+++ b/yacl/crypto/tools/benchmark.cc
@@ -18,12 +18,12 @@
 
 namespace yacl::crypto {
 
-void BM_DefaultArguments(benchmark::internal::Benchmark* b) {
+void BM_DefaultArguments(benchmark::internal::Benchmark *b) {
   b->Unit(benchmark::kMillisecond)
       ->Arg(1 << 10)
       ->Arg(1 << 15)
       ->Arg(1 << 20)
-      ->Arg(16777216);  // 2^24
+      ->Arg(16777216); // 2^24
 }
 
 // Register benchmarks for (Tweakable) (Circular) CrHash
@@ -35,7 +35,8 @@ BENCHMARK_REGISTER_F(TheoreticalToolBench, CRHASH_INPLACE)
 BENCHMARK_REGISTER_F(TheoreticalToolBench, CCRHASH)->Apply(BM_DefaultArguments);
 BENCHMARK_REGISTER_F(TheoreticalToolBench, CCRHASH_INPLACE)
     ->Apply(BM_DefaultArguments);
-BENCHMARK_REGISTER_F(TheoreticalToolBench, TCCRHASH)->Apply(BM_DefaultArguments);
+BENCHMARK_REGISTER_F(TheoreticalToolBench, TCCRHASH)
+    ->Apply(BM_DefaultArguments);
 BENCHMARK_REGISTER_F(TheoreticalToolBench, TCCRHASH_INPLACE)
     ->Apply(BM_DefaultArguments);
 
@@ -48,4 +49,4 @@ BENCHMARK_REGISTER_F(FillPRandBench, FillPRand_AES128_ECB)
 BENCHMARK_REGISTER_F(FillPRandBench, FillPRandWithMersennePrime_AES128_ECB)
     ->Apply(BM_DefaultArguments);
 
-}  // namespace yacl::crypto
+} // namespace yacl::crypto

--- a/yacl/crypto/tools/benchmark.h
+++ b/yacl/crypto/tools/benchmark.h
@@ -121,6 +121,33 @@ BENCHMARK_DEFINE_F(TheoreticalToolBench, CCRHASH_INPLACE)
   }
 }
 
+BENCHMARK_DEFINE_F(TheoreticalToolBench, TCCRHASH)(benchmark::State& state) {
+  std::vector<uint128_t> input;
+  for (auto _ : state) {
+    state.PauseTiming();
+    size_t n = state.range(0);
+    input.resize(n);
+    std::fill(input.begin(), input.end(), 0);
+
+    state.ResumeTiming();
+    ParaTccrHash_128(absl::MakeSpan(input), 0);
+  }
+}
+
+BENCHMARK_DEFINE_F(TheoreticalToolBench, TCCRHASH_INPLACE)
+(benchmark::State& state) {
+  std::vector<uint128_t> input;
+  for (auto _ : state) {
+    state.PauseTiming();
+    size_t n = state.range(0);
+    input.resize(n);
+    std::fill(input.begin(), input.end(), 0);
+
+    state.ResumeTiming();
+    ParaTccrHashInplace_128(absl::MakeSpan(input), 0);
+  }
+}
+
 // 1st arg = numer of desired outputs
 BENCHMARK_DEFINE_F(PrgBench, PrgAesEcb)
 (benchmark::State& state) {

--- a/yacl/crypto/tools/crhash.cc
+++ b/yacl/crypto/tools/crhash.cc
@@ -183,10 +183,10 @@ void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint128_t begin_index)
   // TODO: add dynamic batch size
   alignas(32) std::array<uint128_t, kBatchSize> tmp;  
   auto tmp_span = absl::MakeSpan(tmp);
-  const uint64_t size = inout.size();
+  const uint128_t size = inout.size();
   uint128_t i;
 
-  uint64_t offset = 0;
+  uint128_t offset = 0;
   for (; offset + kBatchSize <= size; offset += kBatchSize) {
     auto inout_span = inout.subspan(offset, kBatchSize);
     // inout_span = RP(x)
@@ -194,8 +194,9 @@ void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint128_t begin_index)
     // tmp_span = RP(x)
     std::memcpy(tmp_span.data(), inout_span.data(), kBatchSize * sizeof(uint128_t));
     // tmp_span = RP(x) ^ i
-    for(i = offset; i < offset + tmp_span.size(); i++) 
-        tmp_span[i] = tmp_span[i] ^ (i + begin_index);  
+    for(i = 0; i < kBatchSize; i++) {
+    	tmp_span[i] ^= (i + offset + begin_index);
+	}   
     // tmp_span = RP(RP(x) ^ i)
     RP.GenForMultiInputsInplace(tmp_span);
     // inout_span = tmp_span ^ inout_span = RP(RP(x) ^ i) ^ RP(x)
@@ -203,13 +204,14 @@ void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint128_t begin_index)
                    inout_span.begin(), inout_span.begin(),
                    std::bit_xor<uint128_t>());
   }
-  uint64_t remain = size - offset;
+  uint128_t remain = size - offset;
   if (remain > 0) {
       auto inout_span = inout.subspan(offset, remain);
       RP.GenForMultiInputsInplace(inout_span);
       std::memcpy(tmp_span.data(), inout_span.data(), remain * sizeof(uint128_t));
-      for(i = offset; i < offset + remain; i++) 
-          tmp_span[i] = tmp_span[i] ^ (i + begin_index);  
+      for(i = 0; i < remain; i++) {
+    	tmp_span[i] ^= (i + offset + begin_index);
+	  }    
       RP.GenForMultiInputsInplace(tmp_span.subspan(0, remain));
       std::transform(tmp_span.begin(), tmp_span.begin() + remain,
                      inout_span.begin(), inout_span.begin(),

--- a/yacl/crypto/tools/crhash.cc
+++ b/yacl/crypto/tools/crhash.cc
@@ -167,8 +167,9 @@ std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x, uint128_t
     // tmp = RP(x)
     std::memcpy(tmp.data(), out.data(), x.size() * sizeof(uint128_t));
     // tmp = RP(x) ^ i
-    for(uint64_t i = 0; i < tmp.size(); i++) 
+    for(uint64_t i = 0; i < tmp.size(); i++) {
         tmp[i] ^= (i + begin_index);
+    }
     // tmp = RP(tmp) = RP(RP(x) ^ i)
     RP.GenForMultiInputsInplace(absl::MakeSpan(tmp));
     // out = tmp ^ out = RP(RP(x) ^ i) ^ RP(x)

--- a/yacl/crypto/tools/crhash.cc
+++ b/yacl/crypto/tools/crhash.cc
@@ -152,7 +152,7 @@ void ParaCcrHashInplace_128(absl::Span<uint128_t> inout) {
 // See GKWY20 paper (https://eprint.iacr.org/2019/074.pdf) Sec 7.4
 // TccrHash(x,i) = RP(RP(x) ^ i) ^ RP(x)
 uint128_t TccrHash_128(uint128_t x, uint128_t i) {
-    const auto& RP = GetCrHashDefaultRP();  // RP为ECB模式的AES
+    const auto& RP = GetCrHashDefaultRP();
     uint128_t tmp = RP.Gen(x);  // tmp = RP(x)
     return RP.Gen(tmp ^ i) ^ tmp;
 }
@@ -161,7 +161,7 @@ uint128_t TccrHash_128(uint128_t x, uint128_t i) {
 std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x, uint128_t begin_index) {
     std::vector<uint128_t> out(x.size());
     std::vector<uint128_t> tmp(x.size());
-    const auto& RP = GetCrHashDefaultRP();  // RP为ECB模式的AES
+    const auto& RP = GetCrHashDefaultRP(); 
     // out = RP(x)
     RP.GenForMultiInputs(x, absl::MakeSpan(out));  
     // tmp = RP(x)

--- a/yacl/crypto/tools/crhash.cc
+++ b/yacl/crypto/tools/crhash.cc
@@ -167,8 +167,8 @@ std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x, uint128_t
     // tmp = RP(x)
     std::memcpy(tmp.data(), out.data(), x.size() * sizeof(uint128_t));
     // tmp = RP(x) ^ i
-    for(uint128_t i = 0; i < tmp.size(); i++) 
-        tmp[i] = tmp[i] ^ (i + begin_index);
+    for(uint64_t i = 0; i < tmp.size(); i++) 
+        tmp[i] ^= (i + begin_index);
     // tmp = RP(tmp) = RP(RP(x) ^ i)
     RP.GenForMultiInputsInplace(absl::MakeSpan(tmp));
     // out = tmp ^ out = RP(RP(x) ^ i) ^ RP(x)
@@ -183,10 +183,10 @@ void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint128_t begin_index)
   // TODO: add dynamic batch size
   alignas(32) std::array<uint128_t, kBatchSize> tmp;  
   auto tmp_span = absl::MakeSpan(tmp);
-  const uint128_t size = inout.size();
-  uint128_t i;
+  const uint64_t size = inout.size();
+  uint64_t i;
 
-  uint128_t offset = 0;
+  uint64_t offset = 0;
   for (; offset + kBatchSize <= size; offset += kBatchSize) {
     auto inout_span = inout.subspan(offset, kBatchSize);
     // inout_span = RP(x)
@@ -204,7 +204,7 @@ void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint128_t begin_index)
                    inout_span.begin(), inout_span.begin(),
                    std::bit_xor<uint128_t>());
   }
-  uint128_t remain = size - offset;
+  uint64_t remain = size - offset;
   if (remain > 0) {
       auto inout_span = inout.subspan(offset, remain);
       RP.GenForMultiInputsInplace(inout_span);

--- a/yacl/crypto/tools/crhash.cc
+++ b/yacl/crypto/tools/crhash.cc
@@ -148,4 +148,73 @@ void ParaCcrHashInplace_128(absl::Span<uint128_t> inout) {
   ParaCrHashInplace_128(inout_span.subspan(offset, remain));
 }
 
+// Tweakable Circular Correlation Robust (TCCR) Hash function 
+// See GKWY20 paper (https://eprint.iacr.org/2019/074.pdf) Sec 7.4
+// TccrHash(x,i) = RP(RP(x) ^ i) ^ RP(x)
+uint128_t TccrHash_128(uint128_t x, uint128_t i) {
+    const auto& RP = GetCrHashDefaultRP();  // RP为ECB模式的AES
+    uint128_t tmp = RP.Gen(x);  // tmp = RP(x)
+    return RP.Gen(tmp ^ i) ^ tmp;
+}
+
+// TccrHash(x,i) for elements in x, i begins with begin_index, return the result
+std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x, uint128_t begin_index) {
+    std::vector<uint128_t> out(x.size());
+    std::vector<uint128_t> tmp(x.size());
+    const auto& RP = GetCrHashDefaultRP();  // RP为ECB模式的AES
+    // out = RP(x)
+    RP.GenForMultiInputs(x, absl::MakeSpan(out));  
+    // tmp = RP(x)
+    std::memcpy(tmp.data(), out.data(), x.size() * sizeof(uint128_t));
+    // tmp = RP(x) ^ i
+    for(uint128_t i = 0; i < tmp.size(); i++) 
+        tmp[i] = tmp[i] ^ (i + begin_index);
+    // tmp = RP(tmp) = RP(RP(x) ^ i)
+    RP.GenForMultiInputsInplace(absl::MakeSpan(tmp));
+    // out = tmp ^ out = RP(RP(x) ^ i) ^ RP(x)
+    std::transform(tmp.begin(), tmp.end(), out.begin(), out.begin(),
+                   std::bit_xor<uint128_t>());
+    return out;
+}
+
+// TccrHash(x,i) for elements in inout (inplace), i begins with begin_index
+void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint128_t begin_index) {
+  const auto& RP = GetCrHashDefaultRP();  
+  // TODO: add dynamic batch size
+  alignas(32) std::array<uint128_t, kBatchSize> tmp;  
+  auto tmp_span = absl::MakeSpan(tmp);
+  const uint64_t size = inout.size();
+  uint128_t i;
+
+  uint64_t offset = 0;
+  for (; offset + kBatchSize <= size; offset += kBatchSize) {
+    auto inout_span = inout.subspan(offset, kBatchSize);
+    // inout_span = RP(x)
+    RP.GenForMultiInputsInplace(inout_span);
+    // tmp_span = RP(x)
+    std::memcpy(tmp_span.data(), inout_span.data(), kBatchSize * sizeof(uint128_t));
+    // tmp_span = RP(x) ^ i
+    for(i = offset; i < offset + tmp_span.size(); i++) 
+        tmp_span[i] = tmp_span[i] ^ (i + begin_index);  
+    // tmp_span = RP(RP(x) ^ i)
+    RP.GenForMultiInputsInplace(tmp_span);
+    // inout_span = tmp_span ^ inout_span = RP(RP(x) ^ i) ^ RP(x)
+    std::transform(tmp_span.begin(), tmp_span.begin() + kBatchSize,
+                   inout_span.begin(), inout_span.begin(),
+                   std::bit_xor<uint128_t>());
+  }
+  uint64_t remain = size - offset;
+  if (remain > 0) {
+      auto inout_span = inout.subspan(offset, remain);
+      RP.GenForMultiInputsInplace(inout_span);
+      std::memcpy(tmp_span.data(), inout_span.data(), remain * sizeof(uint128_t));
+      for(i = offset; i < offset + remain; i++) 
+          tmp_span[i] = tmp_span[i] ^ (i + begin_index);  
+      RP.GenForMultiInputsInplace(tmp_span.subspan(0, remain));
+      std::transform(tmp_span.begin(), tmp_span.begin() + remain,
+                     inout_span.begin(), inout_span.begin(),
+                     std::bit_xor<uint128_t>());
+  }  
+}
+
 }  // namespace yacl::crypto

--- a/yacl/crypto/tools/crhash.cc
+++ b/yacl/crypto/tools/crhash.cc
@@ -151,35 +151,35 @@ void ParaCcrHashInplace_128(absl::Span<uint128_t> inout) {
 // Tweakable Circular Correlation Robust (TCCR) Hash function 
 // See GKWY20 paper (https://eprint.iacr.org/2019/074.pdf) Sec 7.4
 // TccrHash(x,i) = RP(RP(x) ^ i) ^ RP(x)
-uint128_t TccrHash_128(uint128_t x, uint128_t i) {
-    const auto& RP = GetCrHashDefaultRP();
-    uint128_t tmp = RP.Gen(x);  // tmp = RP(x)
-    return RP.Gen(tmp ^ i) ^ tmp;
+uint128_t TccrHash_128(uint128_t x, uint64_t i) {
+  const auto& RP = GetCrHashDefaultRP();
+  uint128_t tmp = RP.Gen(x);  // tmp = RP(x)
+  return RP.Gen(tmp ^ i) ^ tmp;
 }
 
 // TccrHash(x,i) for elements in x, i begins with begin_index, return the result
-std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x, uint128_t begin_index) {
-    std::vector<uint128_t> out(x.size());
-    std::vector<uint128_t> tmp(x.size());
-    const auto& RP = GetCrHashDefaultRP(); 
-    // out = RP(x)
-    RP.GenForMultiInputs(x, absl::MakeSpan(out));  
-    // tmp = RP(x)
-    std::memcpy(tmp.data(), out.data(), x.size() * sizeof(uint128_t));
-    // tmp = RP(x) ^ i
-    for(uint64_t i = 0; i < tmp.size(); i++) {
-        tmp[i] ^= (i + begin_index);
-    }
-    // tmp = RP(tmp) = RP(RP(x) ^ i)
-    RP.GenForMultiInputsInplace(absl::MakeSpan(tmp));
-    // out = tmp ^ out = RP(RP(x) ^ i) ^ RP(x)
-    std::transform(tmp.begin(), tmp.end(), out.begin(), out.begin(),
-                   std::bit_xor<uint128_t>());
-    return out;
+std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x, uint64_t begin_index) {
+  std::vector<uint128_t> out(x.size());
+  std::vector<uint128_t> tmp(x.size());
+  const auto& RP = GetCrHashDefaultRP(); 
+  // out = RP(x)
+  RP.GenForMultiInputs(x, absl::MakeSpan(out));  
+  // tmp = RP(x)
+  std::memcpy(tmp.data(), out.data(), x.size() * sizeof(uint128_t));
+  // tmp = RP(x) ^ i
+  for(uint64_t i = 0; i < tmp.size(); i++) {
+    tmp[i] ^= (i + begin_index);
+  } 
+  // tmp = RP(tmp) = RP(RP(x) ^ i)
+  RP.GenForMultiInputsInplace(absl::MakeSpan(tmp));
+  // out = tmp ^ out = RP(RP(x) ^ i) ^ RP(x)
+  std::transform(tmp.begin(), tmp.end(), out.begin(), out.begin(),
+                 std::bit_xor<uint128_t>());
+  return out;
 }
 
 // TccrHash(x,i) for elements in inout (inplace), i begins with begin_index
-void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint128_t begin_index) {
+void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint64_t begin_index) {
   const auto& RP = GetCrHashDefaultRP();  
   // TODO: add dynamic batch size
   alignas(32) std::array<uint128_t, kBatchSize> tmp;  
@@ -196,7 +196,7 @@ void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint128_t begin_index)
     std::memcpy(tmp_span.data(), inout_span.data(), kBatchSize * sizeof(uint128_t));
     // tmp_span = RP(x) ^ i
     for(i = 0; i < kBatchSize; i++) {
-    	tmp_span[i] ^= (i + offset + begin_index);
+      tmp_span[i] ^= (i + offset + begin_index);
 	}   
     // tmp_span = RP(RP(x) ^ i)
     RP.GenForMultiInputsInplace(tmp_span);
@@ -207,16 +207,16 @@ void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint128_t begin_index)
   }
   uint64_t remain = size - offset;
   if (remain > 0) {
-      auto inout_span = inout.subspan(offset, remain);
-      RP.GenForMultiInputsInplace(inout_span);
-      std::memcpy(tmp_span.data(), inout_span.data(), remain * sizeof(uint128_t));
-      for(i = 0; i < remain; i++) {
-    	tmp_span[i] ^= (i + offset + begin_index);
-	  }    
-      RP.GenForMultiInputsInplace(tmp_span.subspan(0, remain));
-      std::transform(tmp_span.begin(), tmp_span.begin() + remain,
-                     inout_span.begin(), inout_span.begin(),
-                     std::bit_xor<uint128_t>());
+    auto inout_span = inout.subspan(offset, remain);
+    RP.GenForMultiInputsInplace(inout_span);
+    std::memcpy(tmp_span.data(), inout_span.data(), remain * sizeof(uint128_t));
+    for(i = 0; i < remain; i++) {
+      tmp_span[i] ^= (i + offset + begin_index);
+	}    
+    RP.GenForMultiInputsInplace(tmp_span.subspan(0, remain));
+    std::transform(tmp_span.begin(), tmp_span.begin() + remain,
+                   inout_span.begin(), inout_span.begin(),
+                   std::bit_xor<uint128_t>());
   }  
 }
 

--- a/yacl/crypto/tools/crhash.cc
+++ b/yacl/crypto/tools/crhash.cc
@@ -34,7 +34,7 @@ constexpr uint64_t kBatchSize = 1024;
 // CcrHash = RP(Sigma(x)) ^ Sigma(x)
 // Sigma(x) = (x.left ^ x.right) || x.left
 inline uint128_t Sigma(uint128_t x) {
-  auto _x = _mm_loadu_si128(reinterpret_cast<__m128i*>(&x));
+  auto _x = _mm_loadu_si128(reinterpret_cast<__m128i *>(&x));
   auto exchange = _mm_shuffle_epi32(_x, 0b01001110);
   auto left = _mm_unpackhi_epi64(_x, _mm_setzero_si128());
   return reinterpret_cast<uint128_t>(_mm_xor_si128(exchange, left));
@@ -45,11 +45,11 @@ inline std::vector<uint128_t> Sigma(absl::Span<const uint128_t> x) {
 
   std::vector<uint128_t> ret(num);
   auto zero = _mm_setzero_si128();
-  auto* dst = reinterpret_cast<__m128i*>(ret.data());
-  const auto* src = reinterpret_cast<const __m128i*>(x.data());
-  const auto* end = src + num;
+  auto *dst = reinterpret_cast<__m128i *>(ret.data());
+  const auto *src = reinterpret_cast<const __m128i *>(x.data());
+  const auto *end = src + num;
   for (; src != end; ++src, ++dst) {
-    auto _xi = _mm_loadu_si128(src);  // _xi = x[i]
+    auto _xi = _mm_loadu_si128(src); // _xi = x[i]
     // exchange = _xi.right || _xi.left
     auto exchange = _mm_shuffle_epi32(_xi, 0b01001110);
     // high  = _xi.left || zero
@@ -63,10 +63,10 @@ inline std::vector<uint128_t> Sigma(absl::Span<const uint128_t> x) {
 inline void SigmaInplace(absl::Span<uint128_t> x) {
   const uint32_t num = x.size();
   auto zero = _mm_setzero_si128();
-  auto* ptr = reinterpret_cast<__m128i*>(x.data());
-  auto* end = ptr + num;
+  auto *ptr = reinterpret_cast<__m128i *>(x.data());
+  auto *end = ptr + num;
   for (; ptr != end; ++ptr) {
-    auto _xi = _mm_loadu_si128(ptr);  // _xi = x[i]
+    auto _xi = _mm_loadu_si128(ptr); // _xi = x[i]
     // exchange = _xi.right || _xi.left
     auto exchange = _mm_shuffle_epi32(_xi, 0b01001110);
     // high  = _xi.left || zero
@@ -76,22 +76,22 @@ inline void SigmaInplace(absl::Span<uint128_t> x) {
   }
 }
 
-RP& GetCrHashDefaultRP() {
+RP &GetCrHashDefaultRP() {
   static RP rp(RP::Ctype::AES128_ECB, RP::kDefaultRpKey, RP::kDefaultRpIV);
   return rp;
 }
 
-}  // namespace
+} // namespace
 
 uint128_t CrHash_128(uint128_t x) {
-  const auto& RP = GetCrHashDefaultRP();
+  const auto &RP = GetCrHashDefaultRP();
   return RP.Gen(x) ^ x;
 }
 
 // FIXME: Rename to BatchCrHash_128
 std::vector<uint128_t> ParaCrHash_128(absl::Span<const uint128_t> x) {
   std::vector<uint128_t> out(x.size());
-  const auto& RP = GetCrHashDefaultRP();
+  const auto &RP = GetCrHashDefaultRP();
   RP.GenForMultiInputs(x, absl::MakeSpan(out));
   std::transform(x.begin(), x.end(), out.begin(), out.begin(),
                  std::bit_xor<uint128_t>());
@@ -100,7 +100,7 @@ std::vector<uint128_t> ParaCrHash_128(absl::Span<const uint128_t> x) {
 
 // FIXME: Rename to BatchCrHashInplace_128
 void ParaCrHashInplace_128(absl::Span<uint128_t> inout) {
-  const auto& RP = GetCrHashDefaultRP();
+  const auto &RP = GetCrHashDefaultRP();
   // TODO: add dynamic batch size
   alignas(32) std::array<uint128_t, kBatchSize> tmp;
   auto tmp_span = absl::MakeSpan(tmp);
@@ -148,28 +148,29 @@ void ParaCcrHashInplace_128(absl::Span<uint128_t> inout) {
   ParaCrHashInplace_128(inout_span.subspan(offset, remain));
 }
 
-// Tweakable Circular Correlation Robust (TCCR) Hash function 
+// Tweakable Circular Correlation Robust (TCCR) Hash function
 // See GKWY20 paper (https://eprint.iacr.org/2019/074.pdf) Sec 7.4
 // TccrHash(x,i) = RP(RP(x) ^ i) ^ RP(x)
 uint128_t TccrHash_128(uint128_t x, uint64_t i) {
-  const auto& RP = GetCrHashDefaultRP();
-  uint128_t tmp = RP.Gen(x);  // tmp = RP(x)
+  const auto &RP = GetCrHashDefaultRP();
+  uint128_t tmp = RP.Gen(x); // tmp = RP(x)
   return RP.Gen(tmp ^ i) ^ tmp;
 }
 
 // TccrHash(x,i) for elements in x, i begins with begin_index, return the result
-std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x, uint64_t begin_index) {
+std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x,
+                                        uint64_t begin_index) {
   std::vector<uint128_t> out(x.size());
   std::vector<uint128_t> tmp(x.size());
-  const auto& RP = GetCrHashDefaultRP(); 
+  const auto &RP = GetCrHashDefaultRP();
   // out = RP(x)
-  RP.GenForMultiInputs(x, absl::MakeSpan(out));  
+  RP.GenForMultiInputs(x, absl::MakeSpan(out));
   // tmp = RP(x)
   std::memcpy(tmp.data(), out.data(), x.size() * sizeof(uint128_t));
   // tmp = RP(x) ^ i
-  for(uint64_t i = 0; i < tmp.size(); i++) {
+  for (uint64_t i = 0; i < tmp.size(); i++) {
     tmp[i] ^= (i + begin_index);
-  } 
+  }
   // tmp = RP(tmp) = RP(RP(x) ^ i)
   RP.GenForMultiInputsInplace(absl::MakeSpan(tmp));
   // out = tmp ^ out = RP(RP(x) ^ i) ^ RP(x)
@@ -179,10 +180,11 @@ std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x, uint64_t 
 }
 
 // TccrHash(x,i) for elements in inout (inplace), i begins with begin_index
-void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint64_t begin_index) {
-  const auto& RP = GetCrHashDefaultRP();  
+void ParaTccrHashInplace_128(absl::Span<uint128_t> inout,
+                             uint64_t begin_index) {
+  const auto &RP = GetCrHashDefaultRP();
   // TODO: add dynamic batch size
-  alignas(32) std::array<uint128_t, kBatchSize> tmp;  
+  alignas(32) std::array<uint128_t, kBatchSize> tmp;
   auto tmp_span = absl::MakeSpan(tmp);
   const uint64_t size = inout.size();
   uint64_t i;
@@ -193,11 +195,12 @@ void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint64_t begin_index) 
     // inout_span = RP(x)
     RP.GenForMultiInputsInplace(inout_span);
     // tmp_span = RP(x)
-    std::memcpy(tmp_span.data(), inout_span.data(), kBatchSize * sizeof(uint128_t));
+    std::memcpy(tmp_span.data(), inout_span.data(),
+                kBatchSize * sizeof(uint128_t));
     // tmp_span = RP(x) ^ i
-    for(i = 0; i < kBatchSize; i++) {
+    for (i = 0; i < kBatchSize; i++) {
       tmp_span[i] ^= (i + offset + begin_index);
-	}   
+    }
     // tmp_span = RP(RP(x) ^ i)
     RP.GenForMultiInputsInplace(tmp_span);
     // inout_span = tmp_span ^ inout_span = RP(RP(x) ^ i) ^ RP(x)
@@ -210,14 +213,14 @@ void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint64_t begin_index) 
     auto inout_span = inout.subspan(offset, remain);
     RP.GenForMultiInputsInplace(inout_span);
     std::memcpy(tmp_span.data(), inout_span.data(), remain * sizeof(uint128_t));
-    for(i = 0; i < remain; i++) {
+    for (i = 0; i < remain; i++) {
       tmp_span[i] ^= (i + offset + begin_index);
-	}    
+    }
     RP.GenForMultiInputsInplace(tmp_span.subspan(0, remain));
     std::transform(tmp_span.begin(), tmp_span.begin() + remain,
                    inout_span.begin(), inout_span.begin(),
                    std::bit_xor<uint128_t>());
-  }  
+  }
 }
 
-}  // namespace yacl::crypto
+} // namespace yacl::crypto

--- a/yacl/crypto/tools/crhash.h
+++ b/yacl/crypto/tools/crhash.h
@@ -48,7 +48,15 @@ std::vector<uint128_t> ParaCcrHash_128(absl::Span<const uint128_t> x);
 // inplace parallel ccrhash for many blocks
 void ParaCcrHashInplace_128(absl::Span<uint128_t> inout);
 
-// TODO(@shanzhu) Tweakable Correlation Robust Hash function (Multiple Blocks)
-// See https://eprint.iacr.org/2019/074.pdf Sec 7.4
+// Tweakable Circular Correlation Robust (TCCR) Hash function 
+// See GKWY20 paper (https://eprint.iacr.org/2019/074.pdf) Sec 7.4
+// tccrhash for a single block, TccrHash(x,i) = RP(RP(x) ^ i) ^ RP(x)
+uint128_t TccrHash_128(uint128_t x, uint128_t i);
+
+// parallel tccrhash for multiple blocks
+std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x, uint128_t begin_index);
+
+// inplace parallel tccrhash for many blocks
+void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint128_t begin_index);
 
 }  // namespace yacl::crypto

--- a/yacl/crypto/tools/crhash.h
+++ b/yacl/crypto/tools/crhash.h
@@ -51,12 +51,12 @@ void ParaCcrHashInplace_128(absl::Span<uint128_t> inout);
 // Tweakable Circular Correlation Robust (TCCR) Hash function 
 // See GKWY20 paper (https://eprint.iacr.org/2019/074.pdf) Sec 7.4
 // tccrhash for a single block, TccrHash(x,i) = RP(RP(x) ^ i) ^ RP(x)
-uint128_t TccrHash_128(uint128_t x, uint128_t i);
+uint128_t TccrHash_128(uint128_t x, uint64_t i);
 
 // parallel tccrhash for multiple blocks
-std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x, uint128_t begin_index);
+std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x, uint64_t begin_index);
 
 // inplace parallel tccrhash for many blocks
-void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint128_t begin_index);
+void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint64_t begin_index);
 
 }  // namespace yacl::crypto

--- a/yacl/crypto/tools/crhash.h
+++ b/yacl/crypto/tools/crhash.h
@@ -48,15 +48,16 @@ std::vector<uint128_t> ParaCcrHash_128(absl::Span<const uint128_t> x);
 // inplace parallel ccrhash for many blocks
 void ParaCcrHashInplace_128(absl::Span<uint128_t> inout);
 
-// Tweakable Circular Correlation Robust (TCCR) Hash function 
+// Tweakable Circular Correlation Robust (TCCR) Hash function
 // See GKWY20 paper (https://eprint.iacr.org/2019/074.pdf) Sec 7.4
 // tccrhash for a single block, TccrHash(x,i) = RP(RP(x) ^ i) ^ RP(x)
 uint128_t TccrHash_128(uint128_t x, uint64_t i);
 
 // parallel tccrhash for multiple blocks
-std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x, uint64_t begin_index);
+std::vector<uint128_t> ParaTccrHash_128(absl::Span<const uint128_t> x,
+                                        uint64_t begin_index);
 
 // inplace parallel tccrhash for many blocks
 void ParaTccrHashInplace_128(absl::Span<uint128_t> inout, uint64_t begin_index);
 
-}  // namespace yacl::crypto
+} // namespace yacl::crypto

--- a/yacl/crypto/tools/crhash_test.cc
+++ b/yacl/crypto/tools/crhash_test.cc
@@ -108,4 +108,46 @@ TEST(RPTest, ParaCcrHashInplaceWorks) {
   EXPECT_EQ(absl::MakeSpan(inout), absl::MakeSpan(inout_copy));
 }
 
+TEST(RPTest, TccrHashWorks) {
+  uint128_t x = FastRandU128();
+  uint128_t y = FastRandU128();
+  uint128_t id1 = FastRandU128();
+  uint128_t id2 = FastRandU128();
+
+  EXPECT_NE(x, y);
+  EXPECT_NE(id1, id2);
+  EXPECT_NE(TccrHash_128(x, id1), 0);  
+  EXPECT_EQ(TccrHash_128(x, id1), TccrHash_128(x, id1));
+  EXPECT_NE(TccrHash_128(x, id1), TccrHash_128(y, id1));
+  /* when id1 != id2, expect Hash(x, id1) != Hash(x, id2) */
+  EXPECT_NE(TccrHash_128(x, id1), TccrHash_128(x, id2));  
+}
+
+TEST(RPTest, ParaTccrHashWorks) {
+  const auto size = 20;
+
+  std::vector<uint128_t> zeros(size, 0);
+  auto input = RandomBlocks(size);
+  auto output = ParaTccrHash_128(absl::MakeSpan(input), 0);
+
+  EXPECT_NE(absl::MakeSpan(output), absl::MakeSpan(zeros));
+  EXPECT_NE(absl::MakeSpan(output), absl::MakeSpan(input));
+  EXPECT_EQ(absl::MakeSpan(output), ParaTccrHash_128(absl::MakeSpan(input), 0));
+}
+
+TEST(RPTest, ParaTccrHashInplaceWorks) {
+  const auto size = 20;
+
+  std::vector<uint128_t> zeros(size, 0);
+  auto inout = RandomBlocks(size);
+  auto inout_copy = inout;
+
+  ParaTccrHashInplace_128(absl::MakeSpan(inout), 0);
+  EXPECT_NE(absl::MakeSpan(inout), absl::MakeSpan(zeros));
+  EXPECT_NE(absl::MakeSpan(inout), absl::MakeSpan(inout_copy));
+
+  ParaTccrHashInplace_128(absl::MakeSpan(inout_copy), 0);
+  EXPECT_EQ(absl::MakeSpan(inout), absl::MakeSpan(inout_copy));
+}
+
 }  // namespace yacl::crypto

--- a/yacl/crypto/tools/crhash_test.cc
+++ b/yacl/crypto/tools/crhash_test.cc
@@ -111,8 +111,8 @@ TEST(RPTest, ParaCcrHashInplaceWorks) {
 TEST(RPTest, TccrHashWorks) {
   uint128_t x = FastRandU128();
   uint128_t y = FastRandU128();
-  uint128_t id1 = FastRandU128();
-  uint128_t id2 = FastRandU128();
+  uint64_t id1 = FastRandU64();
+  uint64_t id2 = FastRandU64();
 
   EXPECT_NE(x, y);
   EXPECT_NE(id1, id2);

--- a/yacl/crypto/tools/crhash_test.cc
+++ b/yacl/crypto/tools/crhash_test.cc
@@ -32,7 +32,7 @@ inline auto RandomBlocks(size_t length) {
   return rand_inputs;
 }
 
-}  // namespace
+} // namespace
 
 TEST(RPTest, CrHashWorks) {
   uint128_t x = FastRandU128();
@@ -116,11 +116,11 @@ TEST(RPTest, TccrHashWorks) {
 
   EXPECT_NE(x, y);
   EXPECT_NE(id1, id2);
-  EXPECT_NE(TccrHash_128(x, id1), 0);  
+  EXPECT_NE(TccrHash_128(x, id1), 0);
   EXPECT_EQ(TccrHash_128(x, id1), TccrHash_128(x, id1));
   EXPECT_NE(TccrHash_128(x, id1), TccrHash_128(y, id1));
   /* when id1 != id2, expect Hash(x, id1) != Hash(x, id2) */
-  EXPECT_NE(TccrHash_128(x, id1), TccrHash_128(x, id2));  
+  EXPECT_NE(TccrHash_128(x, id1), TccrHash_128(x, id2));
 }
 
 TEST(RPTest, ParaTccrHashWorks) {
@@ -150,4 +150,4 @@ TEST(RPTest, ParaTccrHashInplaceWorks) {
   EXPECT_EQ(absl::MakeSpan(inout), absl::MakeSpan(inout_copy));
 }
 
-}  // namespace yacl::crypto
+} // namespace yacl::crypto

--- a/yacl/kernel/algorithms/kos_ote.cc
+++ b/yacl/kernel/algorithms/kos_ote.cc
@@ -207,8 +207,8 @@ void KosOtExtSend(const std::shared_ptr<link::Context>& ctx,
   auto batch1 = VecXorMonochrome(absl::MakeSpan(q_ext), delta);
 
   if (!cot) {
-    ParaCrHashInplace_128(absl::MakeSpan(batch0));
-    ParaCrHashInplace_128(absl::MakeSpan(batch1));
+    ParaTccrHashInplace_128(absl::MakeSpan(batch0), 0);
+    ParaTccrHashInplace_128(absl::MakeSpan(batch1), 0);
   }
 
   for (size_t i = 0; i < ot_num_valid; i++) {
@@ -303,7 +303,7 @@ void KosOtExtRecv(const std::shared_ptr<link::Context>& ctx,
 
   t_ext.resize(ot_num_valid);
   if (!cot) {
-    ParaCrHashInplace_128(absl::MakeSpan(t_ext));
+    ParaTccrHashInplace_128(absl::MakeSpan(t_ext), 0);
   }
   for (size_t i = 0; i < ot_num_valid; i++) {
     recv_blocks[i] = t_ext[i];

--- a/yacl/kernel/algorithms/kos_ote.cc
+++ b/yacl/kernel/algorithms/kos_ote.cc
@@ -207,6 +207,8 @@ void KosOtExtSend(const std::shared_ptr<link::Context>& ctx,
   auto batch1 = VecXorMonochrome(absl::MakeSpan(q_ext), delta);
 
   if (!cot) {
+  	// 0 is the beginning index of OT message pairs (0,1,2,3,...) 
+  	// For every pair of OT messages m0 and m1, they use the same tweak (index)
     ParaTccrHashInplace_128(absl::MakeSpan(batch0), 0);
     ParaTccrHashInplace_128(absl::MakeSpan(batch1), 0);
   }

--- a/yacl/kernel/algorithms/kos_ote.cc
+++ b/yacl/kernel/algorithms/kos_ote.cc
@@ -68,7 +68,7 @@ inline std::vector<uint128_t> VecXorMonochrome(absl::Span<const uint128_t> in,
 
 inline std::pair<std::array<std::vector<uint128_t>, kKappa>,
                  std::array<std::vector<uint128_t>, kKappa>>
-ExtendBaseOt(const OtSendStore& base_ot, size_t block_num) {
+ExtendBaseOt(const OtSendStore &base_ot, size_t block_num) {
   std::array<std::vector<uint128_t>, kKappa> base_ot_ext0;
   std::array<std::vector<uint128_t>, kKappa> base_ot_ext1;
   for (size_t k = 0; k < base_ot.Size(); ++k) {
@@ -80,8 +80,8 @@ ExtendBaseOt(const OtSendStore& base_ot, size_t block_num) {
   return std::make_pair(base_ot_ext0, base_ot_ext1);
 }
 
-inline std::array<std::vector<uint128_t>, kKappa> ExtendBaseOt(
-    const OtRecvStore& base_ot, size_t block_num) {
+inline std::array<std::vector<uint128_t>, kKappa>
+ExtendBaseOt(const OtRecvStore &base_ot, size_t block_num) {
   std::array<std::vector<uint128_t>, kKappa> base_ot_ext;
   for (size_t k = 0; k < base_ot.Size(); ++k) {
     base_ot_ext[k].resize(block_num);
@@ -90,8 +90,8 @@ inline std::array<std::vector<uint128_t>, kKappa> ExtendBaseOt(
   return base_ot_ext;
 }
 
-inline dynamic_bitset<uint128_t> ExtendChoice(
-    const dynamic_bitset<uint128_t>& choices, size_t final_size) {
+inline dynamic_bitset<uint128_t>
+ExtendChoice(const dynamic_bitset<uint128_t> &choices, size_t final_size) {
   // Extend choices to batch_num * kBlockNum bits
   // 1st part (valid_ot_num bits): original ot choices
   // 2nd part (verify_ot_num bits): rand bits used for checking
@@ -109,20 +109,19 @@ inline dynamic_bitset<uint128_t> ExtendChoice(
   return choices_ext;
 }
 
-}  // namespace
+} // namespace
 
-void KosOtExtSend(const std::shared_ptr<link::Context>& ctx,
-                  const OtRecvStore& base_ot,
+void KosOtExtSend(const std::shared_ptr<link::Context> &ctx,
+                  const OtRecvStore &base_ot,
                   absl::Span<std::array<uint128_t, 2>> send_blocks, bool cot) {
-  static_assert(kS == 64,
-                "Currently, KOS only support statistical "
-                "security = 64 bit");
+  static_assert(kS == 64, "Currently, KOS only support statistical "
+                          "security = 64 bit");
   YACL_ENFORCE(ctx->WorldSize() == 2);
   YACL_ENFORCE(base_ot.Size() == kKappa);
   YACL_ENFORCE(!send_blocks.empty());
 
   const size_t ot_num_valid = send_blocks.size();
-  const size_t ot_num_ext = ot_num_valid + kS;  // without batch padding
+  const size_t ot_num_ext = ot_num_valid + kS; // without batch padding
   const size_t batch_num = (ot_num_ext + kBatchSize - 1) / kBatchSize;
   const size_t block_num = batch_num * kBatchSize / 128;
 
@@ -135,10 +134,10 @@ void KosOtExtSend(const std::shared_ptr<link::Context>& ctx,
   // For every batch
   for (size_t i = 0; i < batch_num; ++i) {
     // std::array<uint128_t, kBatchSize> recv_msg;
-    const size_t offset = i * kBatchSize / 128;  // block offsets
+    const size_t offset = i * kBatchSize / 128; // block offsets
 
     auto buf = ctx->Recv(ctx->NextRank(), fmt::format("KOS:{}", i));
-    auto recv_msg = absl::MakeSpan(reinterpret_cast<uint128_t*>(buf.data()),
+    auto recv_msg = absl::MakeSpan(reinterpret_cast<uint128_t *>(buf.data()),
                                    buf.size() / sizeof(uint128_t));
     // Q = (u & s) ^ G(K_s) = ((G(K_0) ^ G(K_1) ^ r)) & s) ^ G(K_s)
     // Q = G(K_0) when s is 0
@@ -164,7 +163,7 @@ void KosOtExtSend(const std::shared_ptr<link::Context>& ctx,
   // =================== CONSISTENCY CHECK ===================
   for (size_t k = 0; k < kKappa; ++k) {
     auto k_msg_span = absl::MakeSpan(
-        reinterpret_cast<uint64_t*>(ot_ext[k].data()), 2 * batch_num);
+        reinterpret_cast<uint64_t *>(ot_ext[k].data()), 2 * batch_num);
     q_check[k] = math::Gf64Mul(absl::MakeSpan(rand_samples), k_msg_span);
   }
 
@@ -185,10 +184,10 @@ void KosOtExtSend(const std::shared_ptr<link::Context>& ctx,
   for (size_t i = 0; i < batch_num; ++i) {
     // AVX need to be aligned to 32 bytes.
     alignas(32) std::array<uint128_t, kBatchSize> recv_msg;
-    const size_t offset = i * kBatchSize / 128;  // block offsets
+    const size_t offset = i * kBatchSize / 128; // block offsets
 
     for (size_t k = 0; k < kKappa; ++k) {
-      const auto& ot_slice = ot_ext[k][offset];
+      const auto &ot_slice = ot_ext[k][offset];
       recv_msg[k] = ot_slice;
     }
 
@@ -203,12 +202,12 @@ void KosOtExtSend(const std::shared_ptr<link::Context>& ctx,
 
   uint128_t delta = static_cast<uint128_t>(*base_ot.CopyBitBuf().data());
   q_ext.resize(ot_num_valid);
-  auto& batch0 = q_ext;
+  auto &batch0 = q_ext;
   auto batch1 = VecXorMonochrome(absl::MakeSpan(q_ext), delta);
 
   if (!cot) {
-  	// 0 is the beginning index of OT message pairs (0,1,2,3,...) 
-  	// For every pair of OT messages m0 and m1, they use the same tweak (index)
+    // 0 is the beginning index of OT message pairs (0,1,2,3,...)
+    // For every pair of OT messages m0 and m1, they use the same tweak (index)
     ParaTccrHashInplace_128(absl::MakeSpan(batch0), 0);
     ParaTccrHashInplace_128(absl::MakeSpan(batch1), 0);
   }
@@ -219,20 +218,19 @@ void KosOtExtSend(const std::shared_ptr<link::Context>& ctx,
   }
 }
 
-void KosOtExtRecv(const std::shared_ptr<link::Context>& ctx,
-                  const OtSendStore& base_ot,
-                  const dynamic_bitset<uint128_t>& choices,
+void KosOtExtRecv(const std::shared_ptr<link::Context> &ctx,
+                  const OtSendStore &base_ot,
+                  const dynamic_bitset<uint128_t> &choices,
                   absl::Span<uint128_t> recv_blocks, bool cot) {
-  static_assert(kS == 64,
-                "Currently, KOS only support statistical "
-                "security = 64 bit");
-  YACL_ENFORCE(ctx->WorldSize() == 2);     // Check OT has two parties
-  YACL_ENFORCE(base_ot.Size() == kKappa);  // Check base OT size
+  static_assert(kS == 64, "Currently, KOS only support statistical "
+                          "security = 64 bit");
+  YACL_ENFORCE(ctx->WorldSize() == 2);    // Check OT has two parties
+  YACL_ENFORCE(base_ot.Size() == kKappa); // Check base OT size
   YACL_ENFORCE(recv_blocks.size() == choices.size());
   YACL_ENFORCE(!recv_blocks.empty());
 
   const size_t ot_num_valid = recv_blocks.size();
-  const size_t ot_num_ext = ot_num_valid + kS;  // without batch padding
+  const size_t ot_num_ext = ot_num_valid + kS; // without batch padding
   const size_t batch_num = (ot_num_ext + kBatchSize - 1) / kBatchSize;
   const size_t block_num = batch_num * kBatchSize / 128;
 
@@ -246,12 +244,12 @@ void KosOtExtRecv(const std::shared_ptr<link::Context>& ctx,
   // yacl/crypto-primitives/ot/extension/kkrt_ote.cc For a task of
   // generating 129 OTs, we actually generates 128 * 2 = 256 OTs.
   for (size_t i = 0; i < batch_num; ++i) {
-    const size_t offset = i * kBatchSize / 128;  // block offsets
+    const size_t offset = i * kBatchSize / 128; // block offsets
     uint128_t choice_slice = *(choice_ext.data() + offset);
     std::array<uint128_t, kKappa> send_msg;
     for (size_t k = 0; k < kKappa; ++k) {
-      const auto& ot_slice0 = ot_ext.first[k][offset];
-      const auto& ot_slice1 = ot_ext.second[k][offset];
+      const auto &ot_slice0 = ot_ext.first[k][offset];
+      const auto &ot_slice1 = ot_ext.second[k][offset];
       send_msg[k] = ot_slice0 ^ ot_slice1 ^ choice_slice;
     }
     ctx->SendAsync(
@@ -271,13 +269,13 @@ void KosOtExtRecv(const std::shared_ptr<link::Context>& ctx,
 
   // =================== CONSISTENCY CHECK ===================
   auto choice_span = absl::MakeSpan(
-      reinterpret_cast<uint64_t*>(choice_ext.data()), batch_num * 2);
+      reinterpret_cast<uint64_t *>(choice_ext.data()), batch_num * 2);
   check_msgs.x = math::Gf64Mul(absl::MakeSpan(rand_samples), choice_span);
 
   for (size_t k = 0; k < kKappa; ++k) {
     check_msgs.t[k] = math::Gf64Mul(
         absl::MakeSpan(rand_samples),
-        absl::MakeSpan(reinterpret_cast<uint64_t*>(ot_ext.first[k].data()),
+        absl::MakeSpan(reinterpret_cast<uint64_t *>(ot_ext.first[k].data()),
                        batch_num * 2));
   }
 
@@ -288,7 +286,7 @@ void KosOtExtRecv(const std::shared_ptr<link::Context>& ctx,
   for (size_t i = 0; i < batch_num; ++i) {
     // AVX need to be aligned to 32 bytes.
     alignas(32) std::array<uint128_t, kKappa> t;
-    const size_t offset = i * kBatchSize / 128;  // block offsets
+    const size_t offset = i * kBatchSize / 128; // block offsets
     for (size_t k = 0; k < kKappa; ++k) {
       t[k] = ot_ext.first[k][offset];
     }
@@ -311,4 +309,4 @@ void KosOtExtRecv(const std::shared_ptr<link::Context>& ctx,
     recv_blocks[i] = t_ext[i];
   }
 }
-}  // namespace yacl::crypto
+} // namespace yacl::crypto

--- a/yacl/kernel/algorithms/mpfss.cc
+++ b/yacl/kernel/algorithms/mpfss.cc
@@ -67,8 +67,7 @@ void MpfssSend(const std::shared_ptr<link::Context>& ctx,
     // use TCCR hash for malicious security, or CR for semi-honest
     if (param.is_mal_) {
       ParaTccrHashInplace_128(this_span, i * batch_size);
-	}
-	else {
+	} else {
 	  ParaCrHashInplace_128(this_span);
 	}
     send_msgs[i] =
@@ -110,8 +109,7 @@ void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
     // use TCCR hash for malicious security, or CR for semi-honest
     if (param.is_mal_) {
       ParaTccrHashInplace_128(this_span, i * batch_size);
-	}
-	else {
+	} else {
 	  ParaCrHashInplace_128(this_span);
 	}
     dpf_sum[i] =
@@ -172,8 +170,7 @@ void MpfssSend(const std::shared_ptr<link::Context>& ctx,
     // use TCCR hash for malicious security, or CR for semi-honest
     if (param.is_mal_) {
       ParaTccrHashInplace_128(this_span, i * batch_size);
-	}
-	else {
+	} else {
 	  ParaCrHashInplace_128(this_span);
 	}
 
@@ -227,8 +224,7 @@ void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
     // use TCCR hash for malicious security, or CR for semi-honest
     if (param.is_mal_) {
       ParaTccrHashInplace_128(this_span, i * batch_size);
-	}
-	else {
+	} else {
 	  ParaCrHashInplace_128(this_span);
 	}
 
@@ -311,8 +307,7 @@ void MpfssSend_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // use TCCR hash for malicious security, or CR for semi-honest
       if (param.is_mal_) {
         ParaTccrHashInplace_128(this_span, batch_idx * batch_size);
-	  }
-	  else {
+	  } else {
 	    ParaCrHashInplace_128(this_span);
 	  }  
       // this_span xor
@@ -405,8 +400,7 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // use TCCR hash for malicious security, or CR for semi-honest
       if (param.is_mal_) {
         ParaTccrHashInplace_128(this_span, batch_idx * batch_size);
-	  }
-	  else {
+	  } else {
 	    ParaCrHashInplace_128(this_span);
 	  }  
       // this_span xor
@@ -494,8 +488,7 @@ void MpfssSend_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // use TCCR hash for malicious security, or CR for semi-honest
       if (param.is_mal_) {
         ParaTccrHashInplace_128(this_span.subspan(0, this_size), batch_idx * batch_size);
-	  }
-	  else {
+	  } else {
 	    ParaCrHashInplace_128(this_span.subspan(0, this_size));
 	  }
       // convert to uint64_t
@@ -605,8 +598,7 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // use TCCR hash for malicious security, or CR for semi-honest
       if (param.is_mal_) {
         ParaTccrHashInplace_128(this_span.subspan(0, this_size), batch_idx * batch_size);
-	  }
-	  else {
+	  } else {
 	    ParaCrHashInplace_128(this_span.subspan(0, this_size));
 	  }
       // convert to uint64_t

--- a/yacl/kernel/algorithms/mpfss.cc
+++ b/yacl/kernel/algorithms/mpfss.cc
@@ -64,7 +64,13 @@ void MpfssSend(const std::shared_ptr<link::Context>& ctx,
 
     GywzOtExtSend(ctx, ot_slice, this_size, this_span);
     // Break the correlation
-    ParaCrHashInplace_128(this_span);
+    // use TCCR hash for malicious security, or CR for semi-honest
+    if (param.is_mal_) {
+    	ParaTccrHashInplace_128(this_span, i * batch_size);
+	}
+	else {
+		ParaCrHashInplace_128(this_span);
+	}
     send_msgs[i] =
         std::reduce(this_span.begin(), this_span.end(), send_msgs[i], op.add);
   }
@@ -101,7 +107,13 @@ void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
         i * math::Log2Ceil(batch_size),
         i * math::Log2Ceil(batch_size) + math::Log2Ceil(this_size));
     GywzOtExtRecv(ctx, ot_slice, this_size, indexes[i], this_span);
-    ParaCrHashInplace_128(this_span);
+    // use TCCR hash for malicious security, or CR for semi-honest
+    if (param.is_mal_) {
+    	ParaTccrHashInplace_128(this_span, i * batch_size);
+	}
+	else {
+		ParaCrHashInplace_128(this_span);
+	}
     dpf_sum[i] =
         std::reduce(this_span.begin(), this_span.end(), dpf_sum[i], op.add);
   }
@@ -157,7 +169,13 @@ void MpfssSend(const std::shared_ptr<link::Context>& ctx,
         i * math::Log2Ceil(batch_size) + math::Log2Ceil(this_size));
 
     GywzOtExtSend(ctx, ot_slice, this_size, this_span);
-    ParaCrHashInplace_128(this_span);
+    // use TCCR hash for malicious security, or CR for semi-honest
+    if (param.is_mal_) {
+    	ParaTccrHashInplace_128(this_span, i * batch_size);
+	}
+	else {
+		ParaCrHashInplace_128(this_span);
+	}
 
     // Break the correlation
     std::transform(
@@ -206,7 +224,13 @@ void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
         i * math::Log2Ceil(batch_size),
         i * math::Log2Ceil(batch_size) + math::Log2Ceil(this_size));
     GywzOtExtRecv(ctx, ot_slice, this_size, indexes[i], this_span);
-    ParaCrHashInplace_128(this_span);
+    // use TCCR hash for malicious security, or CR for semi-honest
+    if (param.is_mal_) {
+    	ParaTccrHashInplace_128(this_span, i * batch_size);
+	}
+	else {
+		ParaCrHashInplace_128(this_span);
+	}
 
     std::transform(
         this_span.begin(), this_span.end(), output.data() + i * batch_size,
@@ -284,7 +308,13 @@ void MpfssSend_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // GywzOtExt is single-point COT
       GywzOtExtSend_fixed_index(ot_slice, this_size, this_span, send_span);
       // Use CrHash to break the correlation
-      ParaCrHashInplace_128(this_span);
+      // use TCCR hash for malicious security, or CR for semi-honest
+      if (param.is_mal_) {
+    	  ParaTccrHashInplace_128(this_span, batch_idx * batch_length);
+	  }
+	  else {
+		  ParaCrHashInplace_128(this_span);
+	  }  
       // this_span xor
       dpf_sum[batch_idx] = std::reduce(this_span.begin(), this_span.end(),
                                        dpf_sum[batch_idx], op.add);
@@ -372,7 +402,13 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // GywzOtExt is single-point COT
       GywzOtExtRecv_fixed_index(ot_slice, this_size, this_span, recv_span);
       // Use CrHash to break the correlation
-      ParaCrHashInplace_128(this_span);
+      // use TCCR hash for malicious security, or CR for semi-honest
+      if (param.is_mal_) {
+    	  ParaTccrHashInplace_128(this_span, batch_idx * batch_length);
+	  }
+	  else {
+		  ParaCrHashInplace_128(this_span);
+	  }  
       // this_span xor
       dpf_sum[batch_idx] = std::reduce(this_span.begin(), this_span.end(),
                                        dpf_sum[batch_idx], op.add);
@@ -455,7 +491,13 @@ void MpfssSend_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // GywzOtExt is single-point COT
       GywzOtExtSend_fixed_index(ot_slice, full_size, this_span, send_span);
       // Use CrHash to break the correlation
-      ParaCrHashInplace_128(this_span.subspan(0, this_size));
+      // use TCCR hash for malicious security, or CR for semi-honest
+      if (param.is_mal_) {
+    	  ParaTccrHashInplace_128(this_span.subspan(0, this_size), 0);
+	  }
+	  else {
+	  	  ParaCrHashInplace_128(this_span.subspan(0, this_size));
+	  }
       // convert to uint64_t
       std::transform(this_span.begin(), this_span.begin() + this_size,
                      output.data() + batch_idx * batch_size,
@@ -560,7 +602,13 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // GywzOtExt is single-point COT
       GywzOtExtRecv_fixed_index(ot_slice, full_size, this_span, recv_span);
       // Use CrHash to break the correlation
-      ParaCrHashInplace_128(this_span.subspan(0, this_size));
+      // use TCCR hash for malicious security, or CR for semi-honest
+      if (param.is_mal_) {
+    	  ParaTccrHashInplace_128(this_span.subspan(0, this_size), 0);
+	  }
+	  else {
+	  	  ParaCrHashInplace_128(this_span.subspan(0, this_size));
+	  }
       // convert to uint64_t
       std::transform(this_span.begin(), this_span.begin() + this_size,
                      output.data() + batch_idx * batch_size,

--- a/yacl/kernel/algorithms/mpfss.cc
+++ b/yacl/kernel/algorithms/mpfss.cc
@@ -66,10 +66,10 @@ void MpfssSend(const std::shared_ptr<link::Context>& ctx,
     // Break the correlation
     // use TCCR hash for malicious security, or CR for semi-honest
     if (param.is_mal_) {
-    	ParaTccrHashInplace_128(this_span, i * batch_size);
+      ParaTccrHashInplace_128(this_span, i * batch_size);
 	}
 	else {
-		ParaCrHashInplace_128(this_span);
+	  ParaCrHashInplace_128(this_span);
 	}
     send_msgs[i] =
         std::reduce(this_span.begin(), this_span.end(), send_msgs[i], op.add);
@@ -109,10 +109,10 @@ void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
     GywzOtExtRecv(ctx, ot_slice, this_size, indexes[i], this_span);
     // use TCCR hash for malicious security, or CR for semi-honest
     if (param.is_mal_) {
-    	ParaTccrHashInplace_128(this_span, i * batch_size);
+      ParaTccrHashInplace_128(this_span, i * batch_size);
 	}
 	else {
-		ParaCrHashInplace_128(this_span);
+	  ParaCrHashInplace_128(this_span);
 	}
     dpf_sum[i] =
         std::reduce(this_span.begin(), this_span.end(), dpf_sum[i], op.add);
@@ -171,10 +171,10 @@ void MpfssSend(const std::shared_ptr<link::Context>& ctx,
     GywzOtExtSend(ctx, ot_slice, this_size, this_span);
     // use TCCR hash for malicious security, or CR for semi-honest
     if (param.is_mal_) {
-    	ParaTccrHashInplace_128(this_span, i * batch_size);
+      ParaTccrHashInplace_128(this_span, i * batch_size);
 	}
 	else {
-		ParaCrHashInplace_128(this_span);
+	  ParaCrHashInplace_128(this_span);
 	}
 
     // Break the correlation
@@ -226,10 +226,10 @@ void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
     GywzOtExtRecv(ctx, ot_slice, this_size, indexes[i], this_span);
     // use TCCR hash for malicious security, or CR for semi-honest
     if (param.is_mal_) {
-    	ParaTccrHashInplace_128(this_span, i * batch_size);
+      ParaTccrHashInplace_128(this_span, i * batch_size);
 	}
 	else {
-		ParaCrHashInplace_128(this_span);
+	  ParaCrHashInplace_128(this_span);
 	}
 
     std::transform(
@@ -310,10 +310,10 @@ void MpfssSend_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // Use CrHash to break the correlation
       // use TCCR hash for malicious security, or CR for semi-honest
       if (param.is_mal_) {
-    	  ParaTccrHashInplace_128(this_span, batch_idx * batch_length);
+        ParaTccrHashInplace_128(this_span, batch_idx * batch_size);
 	  }
 	  else {
-		  ParaCrHashInplace_128(this_span);
+	    ParaCrHashInplace_128(this_span);
 	  }  
       // this_span xor
       dpf_sum[batch_idx] = std::reduce(this_span.begin(), this_span.end(),
@@ -404,10 +404,10 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // Use CrHash to break the correlation
       // use TCCR hash for malicious security, or CR for semi-honest
       if (param.is_mal_) {
-    	  ParaTccrHashInplace_128(this_span, batch_idx * batch_length);
+        ParaTccrHashInplace_128(this_span, batch_idx * batch_size);
 	  }
 	  else {
-		  ParaCrHashInplace_128(this_span);
+	    ParaCrHashInplace_128(this_span);
 	  }  
       // this_span xor
       dpf_sum[batch_idx] = std::reduce(this_span.begin(), this_span.end(),
@@ -493,10 +493,10 @@ void MpfssSend_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // Use CrHash to break the correlation
       // use TCCR hash for malicious security, or CR for semi-honest
       if (param.is_mal_) {
-    	  ParaTccrHashInplace_128(this_span.subspan(0, this_size), 0);
+        ParaTccrHashInplace_128(this_span.subspan(0, this_size), batch_idx * batch_size);
 	  }
 	  else {
-	  	  ParaCrHashInplace_128(this_span.subspan(0, this_size));
+	    ParaCrHashInplace_128(this_span.subspan(0, this_size));
 	  }
       // convert to uint64_t
       std::transform(this_span.begin(), this_span.begin() + this_size,
@@ -604,10 +604,10 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // Use CrHash to break the correlation
       // use TCCR hash for malicious security, or CR for semi-honest
       if (param.is_mal_) {
-    	  ParaTccrHashInplace_128(this_span.subspan(0, this_size), 0);
+        ParaTccrHashInplace_128(this_span.subspan(0, this_size), batch_idx * batch_size);
 	  }
 	  else {
-	  	  ParaCrHashInplace_128(this_span.subspan(0, this_size));
+	    ParaCrHashInplace_128(this_span.subspan(0, this_size));
 	  }
       // convert to uint64_t
       std::transform(this_span.begin(), this_span.begin() + this_size,

--- a/yacl/kernel/algorithms/mpfss.cc
+++ b/yacl/kernel/algorithms/mpfss.cc
@@ -32,18 +32,18 @@ namespace {
 constexpr uint32_t kSuperBatch = 16;
 }
 
-void MpfssSend(const std::shared_ptr<link::Context>& ctx,
-               const OtSendStore& /*cot*/ send_ot, const MpFssParam& param,
+void MpfssSend(const std::shared_ptr<link::Context> &ctx,
+               const OtSendStore & /*cot*/ send_ot, const MpFssParam &param,
                absl::Span<const uint128_t> w, absl::Span<uint128_t> output,
-               const MpfssOp<uint128_t>& op) {
+               const MpfssOp<uint128_t> &op) {
   YACL_ENFORCE(param.assumption_ == LpnNoiseAsm::RegularNoise);
   YACL_ENFORCE(output.size() >= param.mp_vole_size_);
   YACL_ENFORCE(w.size() >= param.noise_num_);
   YACL_ENFORCE(send_ot.Size() >= param.require_ot_num_);
 
-  const auto& batch_num = param.noise_num_;
-  const auto& batch_size = param.sp_vole_size_;
-  const auto& last_batch_size = param.last_sp_vole_size_;
+  const auto &batch_num = param.noise_num_;
+  const auto &batch_size = param.sp_vole_size_;
+  const auto &last_batch_size = param.last_sp_vole_size_;
 
   UninitAlignedVector<uint128_t> send_msgs(batch_num, 0);
   std::transform(send_msgs.cbegin(), send_msgs.cend(), w.cbegin(),
@@ -58,18 +58,18 @@ void MpfssSend(const std::shared_ptr<link::Context>& ctx,
     // which might cause unexpected error.
     // It would be better to use "NextSlice" here, but it's not a const
     // function.
-    auto ot_slice = send_ot.Slice(
-        i * math::Log2Ceil(batch_size),
-        i * math::Log2Ceil(batch_size) + math::Log2Ceil(this_size));
+    auto ot_slice = send_ot.Slice(i * math::Log2Ceil(batch_size),
+                                  i * math::Log2Ceil(batch_size) +
+                                      math::Log2Ceil(this_size));
 
     GywzOtExtSend(ctx, ot_slice, this_size, this_span);
     // Break the correlation
     // use TCCR hash for malicious security, or CR for semi-honest
     if (param.is_mal_) {
       ParaTccrHashInplace_128(this_span, i * batch_size);
-	} else {
-	  ParaCrHashInplace_128(this_span);
-	}
+    } else {
+      ParaCrHashInplace_128(this_span);
+    }
     send_msgs[i] =
         std::reduce(this_span.begin(), this_span.end(), send_msgs[i], op.add);
   }
@@ -79,17 +79,17 @@ void MpfssSend(const std::shared_ptr<link::Context>& ctx,
       "MpVole_msg");
 }
 
-void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
-               const OtRecvStore& /*cot*/ recv_ot, const MpFssParam& param,
-               absl::Span<uint128_t> output, const MpfssOp<uint128_t>& op) {
+void MpfssRecv(const std::shared_ptr<link::Context> &ctx,
+               const OtRecvStore & /*cot*/ recv_ot, const MpFssParam &param,
+               absl::Span<uint128_t> output, const MpfssOp<uint128_t> &op) {
   YACL_ENFORCE(param.assumption_ == LpnNoiseAsm::RegularNoise);
   YACL_ENFORCE(output.size() >= param.mp_vole_size_);
   YACL_ENFORCE(recv_ot.Size() >= param.require_ot_num_);
 
-  const auto& batch_num = param.noise_num_;
-  const auto& batch_size = param.sp_vole_size_;
-  const auto& last_batch_size = param.last_sp_vole_size_;
-  const auto& indexes = param.indexes_;
+  const auto &batch_num = param.noise_num_;
+  const auto &batch_size = param.sp_vole_size_;
+  const auto &last_batch_size = param.last_sp_vole_size_;
+  const auto &indexes = param.indexes_;
 
   UninitAlignedVector<uint128_t> dpf_sum(batch_num, 0);
 
@@ -102,16 +102,16 @@ void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
     // which might cause unexpected error.
     // It would be better to use "NextSlice" here, but it's not a const
     // function.
-    auto ot_slice = recv_ot.Slice(
-        i * math::Log2Ceil(batch_size),
-        i * math::Log2Ceil(batch_size) + math::Log2Ceil(this_size));
+    auto ot_slice = recv_ot.Slice(i * math::Log2Ceil(batch_size),
+                                  i * math::Log2Ceil(batch_size) +
+                                      math::Log2Ceil(this_size));
     GywzOtExtRecv(ctx, ot_slice, this_size, indexes[i], this_span);
     // use TCCR hash for malicious security, or CR for semi-honest
     if (param.is_mal_) {
       ParaTccrHashInplace_128(this_span, i * batch_size);
-	} else {
-	  ParaCrHashInplace_128(this_span);
-	}
+    } else {
+      ParaCrHashInplace_128(this_span);
+    }
     dpf_sum[i] =
         std::reduce(this_span.begin(), this_span.end(), dpf_sum[i], op.add);
   }
@@ -120,8 +120,8 @@ void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
   YACL_ENFORCE(static_cast<uint64_t>(recv_buff.size()) >=
                batch_num * sizeof(uint128_t));
 
-  auto recv_msgs =
-      absl::MakeSpan(reinterpret_cast<uint128_t*>(recv_buff.data()), batch_num);
+  auto recv_msgs = absl::MakeSpan(
+      reinterpret_cast<uint128_t *>(recv_buff.data()), batch_num);
   for (uint32_t i = 0; i < batch_num; ++i) {
     auto tmp = op.sub(recv_msgs[i], dpf_sum[i]);
     output[i * batch_size + indexes[i]] =
@@ -129,18 +129,18 @@ void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
   }
 }
 
-void MpfssSend(const std::shared_ptr<link::Context>& ctx,
-               const OtSendStore& /*cot*/ send_ot, const MpFssParam& param,
+void MpfssSend(const std::shared_ptr<link::Context> &ctx,
+               const OtSendStore & /*cot*/ send_ot, const MpFssParam &param,
                absl::Span<const uint64_t> w, absl::Span<uint64_t> output,
-               const MpfssOp<uint64_t>& op) {
+               const MpfssOp<uint64_t> &op) {
   YACL_ENFORCE(param.assumption_ == LpnNoiseAsm::RegularNoise);
   YACL_ENFORCE(output.size() >= param.mp_vole_size_);
   YACL_ENFORCE(w.size() >= param.noise_num_);
   YACL_ENFORCE(send_ot.Size() >= param.require_ot_num_);
 
-  const auto& batch_num = param.noise_num_;
-  const auto& batch_size = param.sp_vole_size_;
-  const auto& last_batch_size = param.last_sp_vole_size_;
+  const auto &batch_num = param.noise_num_;
+  const auto &batch_size = param.sp_vole_size_;
+  const auto &last_batch_size = param.last_sp_vole_size_;
 
   UninitAlignedVector<uint64_t> send_msgs(batch_num, 0);
   std::transform(send_msgs.cbegin(), send_msgs.cend(), w.cbegin(),
@@ -162,22 +162,22 @@ void MpfssSend(const std::shared_ptr<link::Context>& ctx,
     // which might cause unexpected error.
     // It would be better to use "NextSlice" here, but it's not a const
     // function.
-    auto ot_slice = send_ot.Slice(
-        i * math::Log2Ceil(batch_size),
-        i * math::Log2Ceil(batch_size) + math::Log2Ceil(this_size));
+    auto ot_slice = send_ot.Slice(i * math::Log2Ceil(batch_size),
+                                  i * math::Log2Ceil(batch_size) +
+                                      math::Log2Ceil(this_size));
 
     GywzOtExtSend(ctx, ot_slice, this_size, this_span);
     // use TCCR hash for malicious security, or CR for semi-honest
     if (param.is_mal_) {
       ParaTccrHashInplace_128(this_span, i * batch_size);
-	} else {
-	  ParaCrHashInplace_128(this_span);
-	}
+    } else {
+      ParaCrHashInplace_128(this_span);
+    }
 
     // Break the correlation
     std::transform(
         this_span.begin(), this_span.end(), output.data() + i * batch_size,
-        [](const uint128_t& val) { return static_cast<uint64_t>(val); });
+        [](const uint128_t &val) { return static_cast<uint64_t>(val); });
 
     send_msgs[i] = std::reduce(output.data() + i * batch_size,
                                output.data() + i * batch_size + this_size,
@@ -189,17 +189,17 @@ void MpfssSend(const std::shared_ptr<link::Context>& ctx,
       "MpVole_msg");
 }
 
-void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
-               const OtRecvStore& /*cot*/ recv_ot, const MpFssParam& param,
-               absl::Span<uint64_t> output, const MpfssOp<uint64_t>& op) {
+void MpfssRecv(const std::shared_ptr<link::Context> &ctx,
+               const OtRecvStore & /*cot*/ recv_ot, const MpFssParam &param,
+               absl::Span<uint64_t> output, const MpfssOp<uint64_t> &op) {
   YACL_ENFORCE(param.assumption_ == LpnNoiseAsm::RegularNoise);
   YACL_ENFORCE(output.size() >= param.mp_vole_size_);
   YACL_ENFORCE(recv_ot.Size() >= param.require_ot_num_);
 
-  const auto& batch_num = param.noise_num_;
-  const auto& batch_size = param.sp_vole_size_;
-  const auto& last_batch_size = param.last_sp_vole_size_;
-  const auto& indexes = param.indexes_;
+  const auto &batch_num = param.noise_num_;
+  const auto &batch_size = param.sp_vole_size_;
+  const auto &last_batch_size = param.last_sp_vole_size_;
+  const auto &indexes = param.indexes_;
 
   auto dpf_buf =
       Buffer(std::max(batch_size, last_batch_size) * sizeof(uint128_t));
@@ -217,20 +217,20 @@ void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
     // which might cause unexpected error.
     // It would be better to use "NextSlice" here, but it's not a const
     // function.
-    auto ot_slice = recv_ot.Slice(
-        i * math::Log2Ceil(batch_size),
-        i * math::Log2Ceil(batch_size) + math::Log2Ceil(this_size));
+    auto ot_slice = recv_ot.Slice(i * math::Log2Ceil(batch_size),
+                                  i * math::Log2Ceil(batch_size) +
+                                      math::Log2Ceil(this_size));
     GywzOtExtRecv(ctx, ot_slice, this_size, indexes[i], this_span);
     // use TCCR hash for malicious security, or CR for semi-honest
     if (param.is_mal_) {
       ParaTccrHashInplace_128(this_span, i * batch_size);
-	} else {
-	  ParaCrHashInplace_128(this_span);
-	}
+    } else {
+      ParaCrHashInplace_128(this_span);
+    }
 
     std::transform(
         this_span.begin(), this_span.end(), output.data() + i * batch_size,
-        [](const uint128_t& val) { return static_cast<uint64_t>(val); });
+        [](const uint128_t &val) { return static_cast<uint64_t>(val); });
     dpf_sum[i] = std::reduce(output.data() + i * batch_size,
                              output.data() + i * batch_size + this_size,
                              dpf_sum[i], op.add);
@@ -241,7 +241,7 @@ void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
                batch_num * sizeof(uint64_t));
 
   auto recv_msgs =
-      absl::MakeSpan(reinterpret_cast<uint64_t*>(recv_buff.data()), batch_num);
+      absl::MakeSpan(reinterpret_cast<uint64_t *>(recv_buff.data()), batch_num);
   for (uint32_t i = 0; i < batch_num; ++i) {
     auto tmp = op.sub(recv_msgs[i], dpf_sum[i]);
     output[i * batch_size + indexes[i]] =
@@ -249,19 +249,19 @@ void MpfssRecv(const std::shared_ptr<link::Context>& ctx,
   }
 }
 
-void MpfssSend_fixed_index(const std::shared_ptr<link::Context>& ctx,
-                           const OtSendStore& /*cot*/ send_ot,
-                           MpFssParam& param, absl::Span<const uint128_t> w,
+void MpfssSend_fixed_index(const std::shared_ptr<link::Context> &ctx,
+                           const OtSendStore & /*cot*/ send_ot,
+                           MpFssParam &param, absl::Span<const uint128_t> w,
                            absl::Span<uint128_t> output,
-                           const MpfssOp<uint128_t>& op) {
+                           const MpfssOp<uint128_t> &op) {
   YACL_ENFORCE(param.assumption_ == LpnNoiseAsm::RegularNoise);
   YACL_ENFORCE(output.size() >= param.mp_vole_size_);
   YACL_ENFORCE(w.size() >= param.noise_num_);
   YACL_ENFORCE(send_ot.Size() >= param.require_ot_num_);
 
-  const auto& batch_num = param.noise_num_;
-  const auto& batch_size = param.sp_vole_size_;
-  const auto& last_batch_size = param.last_sp_vole_size_;
+  const auto &batch_num = param.noise_num_;
+  const auto &batch_size = param.sp_vole_size_;
+  const auto &last_batch_size = param.last_sp_vole_size_;
   const auto batch_length = math::Log2Ceil(batch_size);
   const auto last_batch_length = math::Log2Ceil(last_batch_size);
 
@@ -307,9 +307,9 @@ void MpfssSend_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // use TCCR hash for malicious security, or CR for semi-honest
       if (param.is_mal_) {
         ParaTccrHashInplace_128(this_span, batch_idx * batch_size);
-	  } else {
-	    ParaCrHashInplace_128(this_span);
-	  }  
+      } else {
+        ParaCrHashInplace_128(this_span);
+      }
       // this_span xor
       dpf_sum[batch_idx] = std::reduce(this_span.begin(), this_span.end(),
                                        dpf_sum[batch_idx], op.add);
@@ -322,33 +322,33 @@ void MpfssSend_fixed_index(const std::shared_ptr<link::Context>& ctx,
                                    sizeof(uint128_t) * total_ot_msg_num),
                  "GYWZ_OTE: messages");
 
-  auto& send_msgs = dpf_sum;
+  auto &send_msgs = dpf_sum;
   ctx->SendAsync(
       ctx->NextRank(),
       ByteContainerView(send_msgs.data(), send_msgs.size() * sizeof(uint128_t)),
       "MPVOLE:messages");
 }
 
-void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
-                           const OtRecvStore& /*cot*/ recv_ot,
-                           MpFssParam& param, absl::Span<uint128_t> output,
-                           const MpfssOp<uint128_t>& op) {
+void MpfssRecv_fixed_index(const std::shared_ptr<link::Context> &ctx,
+                           const OtRecvStore & /*cot*/ recv_ot,
+                           MpFssParam &param, absl::Span<uint128_t> output,
+                           const MpfssOp<uint128_t> &op) {
   YACL_ENFORCE(param.assumption_ == LpnNoiseAsm::RegularNoise);
   YACL_ENFORCE(output.size() >= param.mp_vole_size_);
   YACL_ENFORCE(recv_ot.Size() >= param.require_ot_num_);
 
-  const auto& batch_num = param.noise_num_;
-  const auto& batch_size = param.sp_vole_size_;
-  const auto& last_batch_size = param.last_sp_vole_size_;
+  const auto &batch_num = param.noise_num_;
+  const auto &batch_size = param.sp_vole_size_;
+  const auto &last_batch_size = param.last_sp_vole_size_;
   const auto batch_length = math::Log2Ceil(batch_size);
   const auto last_batch_length = math::Log2Ceil(last_batch_size);
 
-  auto& indexes = param.indexes_;
+  auto &indexes = param.indexes_;
   auto all_gywz_recv_buf = ctx->Recv(ctx->NextRank(), "GYWZ_OTE: messages");
   YACL_ENFORCE(all_gywz_recv_buf.size() ==
                static_cast<int64_t>(param.require_ot_num_ * sizeof(uint128_t)));
   auto all_gywz_recv_span =
-      absl::MakeSpan(reinterpret_cast<uint128_t*>(all_gywz_recv_buf.data()),
+      absl::MakeSpan(reinterpret_cast<uint128_t *>(all_gywz_recv_buf.data()),
                      param.require_ot_num_);
   int64_t ot_msg_offset = 0;
 
@@ -400,9 +400,9 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // use TCCR hash for malicious security, or CR for semi-honest
       if (param.is_mal_) {
         ParaTccrHashInplace_128(this_span, batch_idx * batch_size);
-	  } else {
-	    ParaCrHashInplace_128(this_span);
-	  }  
+      } else {
+        ParaCrHashInplace_128(this_span);
+      }
       // this_span xor
       dpf_sum[batch_idx] = std::reduce(this_span.begin(), this_span.end(),
                                        dpf_sum[batch_idx], op.add);
@@ -414,8 +414,8 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
   auto recv_buff = ctx->Recv(ctx->NextRank(), "MPVOLE:messages");
   YACL_ENFORCE(static_cast<uint64_t>(recv_buff.size()) ==
                batch_num * sizeof(uint128_t));
-  auto recv_msgs =
-      absl::MakeSpan(reinterpret_cast<uint128_t*>(recv_buff.data()), batch_num);
+  auto recv_msgs = absl::MakeSpan(
+      reinterpret_cast<uint128_t *>(recv_buff.data()), batch_num);
 
   for (uint32_t i = 0; i < batch_num; ++i) {
     auto tmp = op.sub(recv_msgs[i], dpf_sum[i]);
@@ -424,19 +424,19 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
   }
 }
 
-void MpfssSend_fixed_index(const std::shared_ptr<link::Context>& ctx,
-                           const OtSendStore& /*cot*/ send_ot,
-                           MpFssParam& param, absl::Span<const uint64_t> w,
+void MpfssSend_fixed_index(const std::shared_ptr<link::Context> &ctx,
+                           const OtSendStore & /*cot*/ send_ot,
+                           MpFssParam &param, absl::Span<const uint64_t> w,
                            absl::Span<uint64_t> output,
-                           const MpfssOp<uint64_t>& op) {
+                           const MpfssOp<uint64_t> &op) {
   YACL_ENFORCE(param.assumption_ == LpnNoiseAsm::RegularNoise);
   YACL_ENFORCE(output.size() >= param.mp_vole_size_);
   YACL_ENFORCE(w.size() >= param.noise_num_);
   YACL_ENFORCE(send_ot.Size() >= param.require_ot_num_);
 
-  const auto& batch_num = param.noise_num_;
-  const auto& batch_size = param.sp_vole_size_;
-  const auto& last_batch_size = param.last_sp_vole_size_;
+  const auto &batch_num = param.noise_num_;
+  const auto &batch_size = param.sp_vole_size_;
+  const auto &last_batch_size = param.last_sp_vole_size_;
   const auto batch_length = math::Log2Ceil(batch_size);
   const auto last_batch_length = math::Log2Ceil(last_batch_size);
 
@@ -487,10 +487,11 @@ void MpfssSend_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // Use CrHash to break the correlation
       // use TCCR hash for malicious security, or CR for semi-honest
       if (param.is_mal_) {
-        ParaTccrHashInplace_128(this_span.subspan(0, this_size), batch_idx * batch_size);
-	  } else {
-	    ParaCrHashInplace_128(this_span.subspan(0, this_size));
-	  }
+        ParaTccrHashInplace_128(this_span.subspan(0, this_size),
+                                batch_idx * batch_size);
+      } else {
+        ParaCrHashInplace_128(this_span.subspan(0, this_size));
+      }
       // convert to uint64_t
       std::transform(this_span.begin(), this_span.begin() + this_size,
                      output.data() + batch_idx * batch_size,
@@ -512,28 +513,28 @@ void MpfssSend_fixed_index(const std::shared_ptr<link::Context>& ctx,
                    "GYWZ_OTE: messages");
   }
 
-  auto& send_msgs = dpf_sum;
+  auto &send_msgs = dpf_sum;
   ctx->SendAsync(
       ctx->NextRank(),
       ByteContainerView(send_msgs.data(), send_msgs.size() * sizeof(uint64_t)),
       "MPVOLE:messages");
 }
 
-void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
-                           const OtRecvStore& /*cot*/ recv_ot,
-                           MpFssParam& param, absl::Span<uint64_t> output,
-                           const MpfssOp<uint64_t>& op) {
+void MpfssRecv_fixed_index(const std::shared_ptr<link::Context> &ctx,
+                           const OtRecvStore & /*cot*/ recv_ot,
+                           MpFssParam &param, absl::Span<uint64_t> output,
+                           const MpfssOp<uint64_t> &op) {
   YACL_ENFORCE(param.assumption_ == LpnNoiseAsm::RegularNoise);
   YACL_ENFORCE(output.size() >= param.mp_vole_size_);
   YACL_ENFORCE(recv_ot.Size() >= param.require_ot_num_);
 
-  const auto& batch_num = param.noise_num_;
-  const auto& batch_size = param.sp_vole_size_;
-  const auto& last_batch_size = param.last_sp_vole_size_;
+  const auto &batch_num = param.noise_num_;
+  const auto &batch_size = param.sp_vole_size_;
+  const auto &last_batch_size = param.last_sp_vole_size_;
   const auto batch_length = math::Log2Ceil(batch_size);
   const auto last_batch_length = math::Log2Ceil(last_batch_size);
 
-  auto& indexes = param.indexes_;
+  auto &indexes = param.indexes_;
 
   const auto super_batch_num = math::DivCeil(batch_num, kSuperBatch);
 
@@ -559,7 +560,7 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
     YACL_ENFORCE(gywz_recv_buf.size() ==
                  static_cast<int64_t>(msg_length * sizeof(uint128_t)));
     auto gywz_recv_msgs = absl::MakeSpan(
-        reinterpret_cast<uint128_t*>(gywz_recv_buf.data()), msg_length);
+        reinterpret_cast<uint128_t *>(gywz_recv_buf.data()), msg_length);
 
     for (uint32_t i = 0; i < bound; ++i) {
       auto this_size = batch_size;
@@ -597,10 +598,11 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
       // Use CrHash to break the correlation
       // use TCCR hash for malicious security, or CR for semi-honest
       if (param.is_mal_) {
-        ParaTccrHashInplace_128(this_span.subspan(0, this_size), batch_idx * batch_size);
-	  } else {
-	    ParaCrHashInplace_128(this_span.subspan(0, this_size));
-	  }
+        ParaTccrHashInplace_128(this_span.subspan(0, this_size),
+                                batch_idx * batch_size);
+      } else {
+        ParaCrHashInplace_128(this_span.subspan(0, this_size));
+      }
       // convert to uint64_t
       std::transform(this_span.begin(), this_span.begin() + this_size,
                      output.data() + batch_idx * batch_size,
@@ -617,7 +619,7 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
   YACL_ENFORCE(static_cast<uint64_t>(recv_buff.size()) ==
                batch_num * sizeof(uint64_t));
   auto recv_msgs =
-      absl::MakeSpan(reinterpret_cast<uint64_t*>(recv_buff.data()), batch_num);
+      absl::MakeSpan(reinterpret_cast<uint64_t *>(recv_buff.data()), batch_num);
 
   for (uint32_t i = 0; i < batch_num; ++i) {
     auto tmp = op.sub(recv_msgs[i], dpf_sum[i]);
@@ -626,4 +628,4 @@ void MpfssRecv_fixed_index(const std::shared_ptr<link::Context>& ctx,
   }
 }
 
-}  // namespace yacl::crypto
+} // namespace yacl::crypto

--- a/yacl/kernel/algorithms/mpfss.h
+++ b/yacl/kernel/algorithms/mpfss.h
@@ -53,7 +53,7 @@ struct MpFssParam {
   LpnNoiseAsm assumption_ = LpnNoiseAsm::RegularNoise;
   std::vector<uint32_t> indexes_ = std::vector<uint32_t>(0);  // size zero
 
-  bool is_mal_{false};
+  bool is_mal_ = false;
 
   MpFssParam() : MpFssParam(1, 2, LpnNoiseAsm::RegularNoise, false) {}
 

--- a/yacl/kernel/algorithms/softspoken_ote.cc
+++ b/yacl/kernel/algorithms/softspoken_ote.cc
@@ -673,8 +673,7 @@ void SoftspokenOtExtSender::Send(
         if (mal_) {
           ParaTccrHashInplace_128(absl::MakeSpan(V[s]), t * super_batch_size + s * kBatchSize);
           ParaTccrHashInplace_128(absl::MakeSpan(V_xor_delta[s]), t * super_batch_size + s * kBatchSize);
-		} 
-		else {
+		} else {
           ParaCrHashInplace_128(absl::MakeSpan(V[s]));
           ParaCrHashInplace_128(absl::MakeSpan(V_xor_delta[s]));
 		}
@@ -714,8 +713,7 @@ void SoftspokenOtExtSender::Send(
       	if (mal_) {
           ParaTccrHashInplace_128(absl::MakeSpan(V[t]), batch_offset + t * kBatchSize);
           ParaTccrHashInplace_128(absl::MakeSpan(V_xor_delta[t]), batch_offset + t * kBatchSize);	
-		}
-		else {
+		} else {
           ParaCrHashInplace_128(absl::MakeSpan(V[t]));
           ParaCrHashInplace_128(absl::MakeSpan(V_xor_delta[t]));
 		}
@@ -1055,8 +1053,7 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
       	// use TCCR hash for malicious security, or CR for semi-honest
         if (mal_) {
           ParaTccrHashInplace_128(absl::MakeSpan(W[s]), t * super_batch_size + s * batch_size);
-		}
-		else {
+		} else {
           ParaCrHashInplace_128(absl::MakeSpan(W[s]));
 		}
       }
@@ -1091,8 +1088,7 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
       	// use TCCR hash for malicious security, or CR for semi-honest
       	if (mal_) {
           ParaTccrHashInplace_128(absl::MakeSpan(W[t]), batch_offset + t * kBatchSize);
-		} 
-		else {
+		} else {
           ParaCrHashInplace_128(absl::MakeSpan(W[t]));
 		}
       }

--- a/yacl/kernel/algorithms/softspoken_ote.cc
+++ b/yacl/kernel/algorithms/softspoken_ote.cc
@@ -670,12 +670,12 @@ void SoftspokenOtExtSender::Send(
       // 4. perform CrHash to break the correlation if cot flag is false
       if (!cot) {
       	// use TCCR hash for malicious security, or CR for semi-honest
-      	if (mal_) {
+        if (mal_) {
           ParaTccrHashInplace_128(absl::MakeSpan(V[s]), t * super_batch_size + s * kBatchSize);
           ParaTccrHashInplace_128(absl::MakeSpan(V_xor_delta[s]), t * super_batch_size + s * kBatchSize);
 		} 
 		else {
-		  ParaCrHashInplace_128(absl::MakeSpan(V[s]));
+          ParaCrHashInplace_128(absl::MakeSpan(V[s]));
           ParaCrHashInplace_128(absl::MakeSpan(V_xor_delta[s]));
 		}
       }
@@ -712,11 +712,11 @@ void SoftspokenOtExtSender::Send(
       if (!cot) {
       	// use TCCR hash for malicious security, or CR for semi-honest
       	if (mal_) {
-      	  ParaTccrHashInplace_128(absl::MakeSpan(V[t]), batch_offset + t * kBatchSize);
+          ParaTccrHashInplace_128(absl::MakeSpan(V[t]), batch_offset + t * kBatchSize);
           ParaTccrHashInplace_128(absl::MakeSpan(V_xor_delta[t]), batch_offset + t * kBatchSize);	
 		}
 		else {
-		  ParaCrHashInplace_128(absl::MakeSpan(V[t]));
+          ParaCrHashInplace_128(absl::MakeSpan(V[t]));
           ParaCrHashInplace_128(absl::MakeSpan(V_xor_delta[t]));
 		}
       }
@@ -1053,11 +1053,11 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
       // 4. perform CrHash to break the correlation if cot flag is false
       if (!cot) {
       	// use TCCR hash for malicious security, or CR for semi-honest
-      	if (mal_) {
-      	  ParaTccrHashInplace_128(absl::MakeSpan(W[s]), t * super_batch_size + s * batch_size);
+        if (mal_) {
+          ParaTccrHashInplace_128(absl::MakeSpan(W[s]), t * super_batch_size + s * batch_size);
 		}
 		else {
-		  ParaCrHashInplace_128(absl::MakeSpan(W[s]));
+          ParaCrHashInplace_128(absl::MakeSpan(W[s]));
 		}
       }
       for (uint64_t j = 0; j < kBatchSize; ++j) {
@@ -1090,10 +1090,10 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
       if (!cot) {
       	// use TCCR hash for malicious security, or CR for semi-honest
       	if (mal_) {
-      	  ParaTccrHashInplace_128(absl::MakeSpan(W[t]), batch_offset + t * kBatchSize);
+          ParaTccrHashInplace_128(absl::MakeSpan(W[t]), batch_offset + t * kBatchSize);
 		} 
 		else {
-		  ParaCrHashInplace_128(absl::MakeSpan(W[t]));
+          ParaCrHashInplace_128(absl::MakeSpan(W[t]));
 		}
       }
       for (uint64_t j = 0; j < limit; ++j) {

--- a/yacl/kernel/algorithms/softspoken_ote.cc
+++ b/yacl/kernel/algorithms/softspoken_ote.cc
@@ -669,8 +669,15 @@ void SoftspokenOtExtSender::Send(
       XorBlock(absl::MakeSpan(V[s]), absl::MakeSpan(V_xor_delta[s]), delta);
       // 4. perform CrHash to break the correlation if cot flag is false
       if (!cot) {
-        ParaCrHashInplace_128(absl::MakeSpan(V[s]));
-        ParaCrHashInplace_128(absl::MakeSpan(V_xor_delta[s]));
+      	// use TCCR hash for malicious security, or CR for semi-honest
+      	if (mal_) {
+          ParaTccrHashInplace_128(absl::MakeSpan(V[s]), t * super_batch_size + s * kBatchSize);
+          ParaTccrHashInplace_128(absl::MakeSpan(V_xor_delta[s]), t * super_batch_size + s * kBatchSize);
+		} 
+		else {
+		  ParaCrHashInplace_128(absl::MakeSpan(V[s]));
+          ParaCrHashInplace_128(absl::MakeSpan(V_xor_delta[s]));
+		}
       }
 
       for (uint64_t j = 0; j < kBatchSize; ++j) {
@@ -703,8 +710,15 @@ void SoftspokenOtExtSender::Send(
       XorBlock(absl::MakeSpan(V[t]), absl::MakeSpan(V_xor_delta[t]), delta);
       // 4. perform CrHash to break the correlation if cot flag is false
       if (!cot) {
-        ParaCrHashInplace_128(absl::MakeSpan(V[t]));
-        ParaCrHashInplace_128(absl::MakeSpan(V_xor_delta[t]));
+      	// use TCCR hash for malicious security, or CR for semi-honest
+      	if (mal_) {
+      	  ParaTccrHashInplace_128(absl::MakeSpan(V[t]), batch_offset + t * kBatchSize);
+          ParaTccrHashInplace_128(absl::MakeSpan(V_xor_delta[t]), batch_offset + t * kBatchSize);	
+		}
+		else {
+		  ParaCrHashInplace_128(absl::MakeSpan(V[t]));
+          ParaCrHashInplace_128(absl::MakeSpan(V_xor_delta[t]));
+		}
       }
 
       const uint64_t limit =
@@ -928,7 +942,7 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
     }
   }
 
-  // deal with normal bathc
+  // deal with normal batch 
   for (uint64_t t = 0; t < batch_num; ++t) {
     // The same as IKNP OTe
     // 1. smallfield/subspace VOLE
@@ -1038,7 +1052,13 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
       MatrixTranspose128(&W[s]);
       // 4. perform CrHash to break the correlation if cot flag is false
       if (!cot) {
-        ParaCrHashInplace_128(absl::MakeSpan(W[s]));
+      	// use TCCR hash for malicious security, or CR for semi-honest
+      	if (mal_) {
+      	  ParaTccrHashInplace_128(absl::MakeSpan(W[s]), t * super_batch_size + s * batch_size);
+		}
+		else {
+		  ParaCrHashInplace_128(absl::MakeSpan(W[s]));
+		}
       }
       for (uint64_t j = 0; j < kBatchSize; ++j) {
         recv_blocks[t * super_batch_size + s * batch_size + j] = W[s][j];
@@ -1046,7 +1066,7 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
     }
   }
 
-  // deal with normal bathc
+  // deal with normal batch
   for (uint64_t t = 0; t < batch_num; ++t) {
     // The same as IKNP OTe
     // 1. smallfield/subspace VOLE
@@ -1068,7 +1088,13 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
           std::min(kBatchSize, numOt - batch_offset - t * kBatchSize);
       // 4. perform CrHash to break the correlation if cot flag is false
       if (!cot) {
-        ParaCrHashInplace_128(absl::MakeSpan(W[t]));
+      	// use TCCR hash for malicious security, or CR for semi-honest
+      	if (mal_) {
+      	  ParaTccrHashInplace_128(absl::MakeSpan(W[t]), batch_offset + t * kBatchSize);
+		} 
+		else {
+		  ParaCrHashInplace_128(absl::MakeSpan(W[t]));
+		}
       }
       for (uint64_t j = 0; j < limit; ++j) {
         recv_blocks[batch_offset + t * kBatchSize + j] = W[t][j];

--- a/yacl/kernel/algorithms/softspoken_ote.cc
+++ b/yacl/kernel/algorithms/softspoken_ote.cc
@@ -48,10 +48,9 @@ namespace {
 
 constexpr uint64_t kBatchSize = 128;
 constexpr uint64_t kKappa = 128;
-constexpr size_t kS = 64;  // statistical security parameter
+constexpr size_t kS = 64; // statistical security parameter
 
-template <typename T = uint64_t>
-struct CheckMsg {
+template <typename T = uint64_t> struct CheckMsg {
   T x = 0;
   std::array<T, kKappa> t{0};
 
@@ -70,8 +69,8 @@ struct CheckMsg {
   }
 };
 
-inline dynamic_bitset<uint128_t> ExtendChoice(
-    const dynamic_bitset<uint128_t>& choices, size_t final_size) {
+inline dynamic_bitset<uint128_t>
+ExtendChoice(const dynamic_bitset<uint128_t> &choices, size_t final_size) {
   // Extend choices to batch_num * kBlockNum bits
   // 1st part (valid_ot_num bits): original ot choices
   // 2nd part (verify_ot_num bits): rand bits used for checking
@@ -92,7 +91,7 @@ inline dynamic_bitset<uint128_t> ExtendChoice(
 inline void XorBlock(absl::Span<const uint128_t> in, absl::Span<uint128_t> out,
                      const uint128_t block) {
   YACL_ENFORCE(out.size() >= in.size());
-  auto reg_block = _mm_load_si128(reinterpret_cast<const __m128i*>(&block));
+  auto reg_block = _mm_load_si128(reinterpret_cast<const __m128i *>(&block));
   for (uint64_t i = 0; i < in.size(); ++i) {
     out[i] = reinterpret_cast<uint128_t>(
         _mm_xor_si128(reinterpret_cast<__m128i>(in[i]), reg_block));
@@ -102,8 +101,7 @@ inline void XorBlock(absl::Span<const uint128_t> in, absl::Span<uint128_t> out,
 // XorReduce
 // Implementation mostly from:
 // https://github.com/osu-crypto/libOTe/blob/master/libOTe/Vole/SoftSpokenOT/SmallFieldVole.cpp
-template <uint64_t k>
-inline void XorReduce(absl::Span<uint128_t> inout) {
+template <uint64_t k> inline void XorReduce(absl::Span<uint128_t> inout) {
   XorReduce<k - 1>(inout);
   const uint64_t buf_size = inout.size();
   constexpr uint64_t stride = 1 << (k - 1);
@@ -137,9 +135,9 @@ inline void XorReduce(uint64_t k, absl::Span<uint128_t> inout) {
 
 inline void XorReduceImpl(uint64_t k, absl::Span<uint128_t> inout) {
   switch (k) {
-#define SWITCH_CASE(n)   \
-  case n:                \
-    XorReduce<n>(inout); \
+#define SWITCH_CASE(n)                                                         \
+  case n:                                                                      \
+    XorReduce<n>(inout);                                                       \
     break;
 
     SWITCH_CASE(1);
@@ -152,17 +150,17 @@ inline void XorReduceImpl(uint64_t k, absl::Span<uint128_t> inout) {
     SWITCH_CASE(8);
 
 #undef SWITCH_CASE
-    default:
-      XorReduce(k, inout);
-      break;
+  default:
+    XorReduce(k, inout);
+    break;
   }
 }
 
-}  // namespace
+} // namespace
 
-void SoftspokenOtExtSend(const std::shared_ptr<link::Context>& ctx,
-                         /* rot */ const OtRecvStore& base_ot,
-                         /* cot */ OtSendStore* out, uint64_t k, uint64_t step,
+void SoftspokenOtExtSend(const std::shared_ptr<link::Context> &ctx,
+                         /* rot */ const OtRecvStore &base_ot,
+                         /* cot */ OtSendStore *out, uint64_t k, uint64_t step,
                          bool mal) {
   std::vector<std::array<uint128_t, 2>> send_blocks(out->Size());
   auto send =
@@ -171,10 +169,10 @@ void SoftspokenOtExtSend(const std::shared_ptr<link::Context>& ctx,
   send.Send(ctx, out);
 }
 
-void SoftspokenOtExtRecv(const std::shared_ptr<link::Context>& ctx,
-                         /* rot */ const OtSendStore& base_ot,
-                         const dynamic_bitset<uint128_t>& choices,
-                         /* cot */ OtRecvStore* out, uint64_t k, uint64_t step,
+void SoftspokenOtExtRecv(const std::shared_ptr<link::Context> &ctx,
+                         /* rot */ const OtSendStore &base_ot,
+                         const dynamic_bitset<uint128_t> &choices,
+                         /* cot */ OtRecvStore *out, uint64_t k, uint64_t step,
                          bool mal) {
   auto recv = SoftspokenOtExtReceiver(k, step, mal,
                                       out->Type() == OtStoreType::Compact);
@@ -237,7 +235,7 @@ SoftspokenOtExtReceiver::SoftspokenOtExtReceiver(uint64_t k, uint64_t step,
 }
 
 void SoftspokenOtExtSender::OneTimeSetup(
-    const std::shared_ptr<link::Context>& ctx) {
+    const std::shared_ptr<link::Context> &ctx) {
   if (inited_) {
     return;
   }
@@ -250,7 +248,7 @@ void SoftspokenOtExtSender::OneTimeSetup(
 }
 
 void SoftspokenOtExtSender::OneTimeSetup(
-    const std::shared_ptr<link::Context>& ctx, const OtRecvStore& base_ot) {
+    const std::shared_ptr<link::Context> &ctx, const OtRecvStore &base_ot) {
   if (inited_) {
     return;
   }
@@ -293,9 +291,9 @@ void SoftspokenOtExtSender::OneTimeSetup(
     // set mask as all zero otherwise.
     for (uint64_t j = 0; j < k_limit; ++j) {
       if (punctured_idx_[i] & (1 << j)) {
-        p_idx_mask_[i * k_ + j] = Uint128Max();  // all one
+        p_idx_mask_[i * k_ + j] = Uint128Max(); // all one
       } else {
-        p_idx_mask_[i * k_ + j] = Uint128Min();  // all zero
+        p_idx_mask_[i * k_ + j] = Uint128Min(); // all zero
       }
     }
     // move leaves[0] to punctured entry
@@ -313,7 +311,7 @@ void SoftspokenOtExtSender::OneTimeSetup(
 }
 
 void SoftspokenOtExtReceiver::OneTimeSetup(
-    const std::shared_ptr<link::Context>& ctx) {
+    const std::shared_ptr<link::Context> &ctx) {
   if (inited_) {
     return;
   }
@@ -324,7 +322,7 @@ void SoftspokenOtExtReceiver::OneTimeSetup(
 }
 
 void SoftspokenOtExtReceiver::OneTimeSetup(
-    const std::shared_ptr<link::Context>& ctx, const OtSendStore& base_ot) {
+    const std::shared_ptr<link::Context> &ctx, const OtSendStore &base_ot) {
   if (inited_) {
     return;
   }
@@ -361,8 +359,8 @@ void SoftspokenOtExtReceiver::OneTimeSetup(
   inited_ = true;
 }
 
-void SoftspokenOtExtSender::GenRot(const std::shared_ptr<link::Context>& ctx,
-                                   uint64_t num_ot, OtSendStore* out) {
+void SoftspokenOtExtSender::GenRot(const std::shared_ptr<link::Context> &ctx,
+                                   uint64_t num_ot, OtSendStore *out) {
   YACL_ENFORCE(out->Size() == num_ot);
   YACL_ENFORCE(out->Type() == OtStoreType::Normal);
   std::vector<std::array<uint128_t, 2>> send_blocks(num_ot);
@@ -373,8 +371,8 @@ void SoftspokenOtExtSender::GenRot(const std::shared_ptr<link::Context>& ctx,
   }
 }
 
-void SoftspokenOtExtSender::GenCot(const std::shared_ptr<link::Context>& ctx,
-                                   uint64_t num_ot, OtSendStore* out) {
+void SoftspokenOtExtSender::GenCot(const std::shared_ptr<link::Context> &ctx,
+                                   uint64_t num_ot, OtSendStore *out) {
   YACL_ENFORCE(out->Size() == num_ot);
   YACL_ENFORCE(out->Type() == OtStoreType::Compact);
   std::vector<std::array<uint128_t, 2>> send_blocks(num_ot);
@@ -385,22 +383,24 @@ void SoftspokenOtExtSender::GenCot(const std::shared_ptr<link::Context>& ctx,
   }
 }
 
-OtSendStore SoftspokenOtExtSender::GenRot(
-    const std::shared_ptr<link::Context>& ctx, uint64_t num_ot) {
+OtSendStore
+SoftspokenOtExtSender::GenRot(const std::shared_ptr<link::Context> &ctx,
+                              uint64_t num_ot) {
   OtSendStore out(num_ot, OtStoreType::Normal);
   GenRot(ctx, num_ot, &out);
   return out;
 }
 
-OtSendStore SoftspokenOtExtSender::GenCot(
-    const std::shared_ptr<link::Context>& ctx, uint64_t num_ot) {
+OtSendStore
+SoftspokenOtExtSender::GenCot(const std::shared_ptr<link::Context> &ctx,
+                              uint64_t num_ot) {
   OtSendStore out(num_ot, OtStoreType::Compact);
   GenCot(ctx, num_ot, &out);
   return out;
 }
 
-void SoftspokenOtExtReceiver::GenRot(const std::shared_ptr<link::Context>& ctx,
-                                     uint64_t num_ot, OtRecvStore* out) {
+void SoftspokenOtExtReceiver::GenRot(const std::shared_ptr<link::Context> &ctx,
+                                     uint64_t num_ot, OtRecvStore *out) {
   YACL_ENFORCE(out->Size() == num_ot);
   YACL_ENFORCE(out->Type() == OtStoreType::Normal);
   auto choices = SecureRandBits<dynamic_bitset<uint128_t>>(num_ot);
@@ -415,9 +415,9 @@ void SoftspokenOtExtReceiver::GenRot(const std::shared_ptr<link::Context>& ctx,
   }
 }
 
-void SoftspokenOtExtReceiver::GenRot(const std::shared_ptr<link::Context>& ctx,
-                                     const dynamic_bitset<uint128_t>& choices,
-                                     OtRecvStore* out) {
+void SoftspokenOtExtReceiver::GenRot(const std::shared_ptr<link::Context> &ctx,
+                                     const dynamic_bitset<uint128_t> &choices,
+                                     OtRecvStore *out) {
   const uint64_t num_ot = choices.size();
   YACL_ENFORCE(out->Size() == num_ot);
   YACL_ENFORCE(out->Type() == OtStoreType::Normal);
@@ -432,15 +432,15 @@ void SoftspokenOtExtReceiver::GenRot(const std::shared_ptr<link::Context>& ctx,
   }
 }
 
-void SoftspokenOtExtReceiver::GenCot(const std::shared_ptr<link::Context>& ctx,
-                                     uint64_t num_ot, OtRecvStore* out) {
+void SoftspokenOtExtReceiver::GenCot(const std::shared_ptr<link::Context> &ctx,
+                                     uint64_t num_ot, OtRecvStore *out) {
   auto choices = SecureRandBits<dynamic_bitset<uint128_t>>(num_ot);
   GenCot(ctx, choices, out);
 }
 
-void SoftspokenOtExtReceiver::GenCot(const std::shared_ptr<link::Context>& ctx,
-                                     const dynamic_bitset<uint128_t>& choices,
-                                     OtRecvStore* out) {
+void SoftspokenOtExtReceiver::GenCot(const std::shared_ptr<link::Context> &ctx,
+                                     const dynamic_bitset<uint128_t> &choices,
+                                     OtRecvStore *out) {
   const uint64_t num_ot = choices.size();
   YACL_ENFORCE(out->Size() == num_ot);
   YACL_ENFORCE(out->Type() ==
@@ -462,17 +462,18 @@ void SoftspokenOtExtReceiver::GenCot(const std::shared_ptr<link::Context>& ctx,
 }
 
 // OtStore-style interface
-OtRecvStore SoftspokenOtExtReceiver::GenRot(
-    const std::shared_ptr<link::Context>& ctx, uint64_t num_ot) {
+OtRecvStore
+SoftspokenOtExtReceiver::GenRot(const std::shared_ptr<link::Context> &ctx,
+                                uint64_t num_ot) {
   OtRecvStore out(num_ot, OtStoreType::Normal);
   // [Warning] low efficiency.
   GenRot(ctx, num_ot, &out);
   return out;
 }
 
-OtRecvStore SoftspokenOtExtReceiver::GenRot(
-    const std::shared_ptr<link::Context>& ctx,
-    const dynamic_bitset<uint128_t>& choices) {
+OtRecvStore
+SoftspokenOtExtReceiver::GenRot(const std::shared_ptr<link::Context> &ctx,
+                                const dynamic_bitset<uint128_t> &choices) {
   OtRecvStore out(choices.size(), OtStoreType::Normal);
   // [Warning] low efficiency.
   GenRot(ctx, choices, &out);
@@ -480,8 +481,9 @@ OtRecvStore SoftspokenOtExtReceiver::GenRot(
 }
 
 // OtStore-style interface
-OtRecvStore SoftspokenOtExtReceiver::GenCot(
-    const std::shared_ptr<link::Context>& ctx, uint64_t num_ot) {
+OtRecvStore
+SoftspokenOtExtReceiver::GenCot(const std::shared_ptr<link::Context> &ctx,
+                                uint64_t num_ot) {
   OtRecvStore out(num_ot, OtStoreType::Normal);
   if (compact_) {
     out = OtRecvStore(num_ot, OtStoreType::Compact);
@@ -494,9 +496,9 @@ OtRecvStore SoftspokenOtExtReceiver::GenCot(
 // Generate Smallfield VOLE and Subspace VOLE
 // Reference: https://eprint.iacr.org/2022/192.pdf Figure 7 & Figure 8
 // s.t.  W = choice * delta + V
-OtRecvStore SoftspokenOtExtReceiver::GenCot(
-    const std::shared_ptr<link::Context>& ctx,
-    const dynamic_bitset<uint128_t>& choices) {
+OtRecvStore
+SoftspokenOtExtReceiver::GenCot(const std::shared_ptr<link::Context> &ctx,
+                                const dynamic_bitset<uint128_t> &choices) {
   OtRecvStore out(choices.size(), OtStoreType::Normal);
   if (compact_) {
     out = OtRecvStore(choices.size(), OtStoreType::Compact);
@@ -533,14 +535,14 @@ void SoftspokenOtExtSender::GenSfVole(absl::Span<uint128_t> hash_buff,
     for (uint64_t i = 0; i < pprf_num_; ++i) {
       const auto limit = std::min(range, hash_size - hash_offset);
       for (uint64_t j = 0; j < limit; ++j) {
-        xor_buff[xor_offset + 1 + j] = hash_buff[hash_offset + j];  // copy
+        xor_buff[xor_offset + 1 + j] = hash_buff[hash_offset + j]; // copy
       }
       xor_buff[xor_offset] = Uint128Min();
       std::swap(
           xor_buff[xor_offset],
-          xor_buff[xor_offset + punctured_idx_[i]]);  // recover punctured entry
-      hash_offset += range;                           // hash_offset = i * range
-      xor_offset += pprf_range_;  // xor_offset = i * pprf_range
+          xor_buff[xor_offset + punctured_idx_[i]]); // recover punctured entry
+      hash_offset += range;                          // hash_offset = i * range
+      xor_offset += pprf_range_; // xor_offset = i * pprf_range
     }
   }
 
@@ -560,8 +562,8 @@ void SoftspokenOtExtSender::GenSfVole(absl::Span<uint128_t> hash_buff,
         V[V_offset + j] =
             xor_buff[xor_offset + 1 + j] ^ (u[i] & p_idx_mask_[V_offset + j]);
       }
-      V_offset += k_;             // V_offset = i * k
-      xor_offset += pprf_range_;  // hash_offset = i * pprf_range
+      V_offset += k_;            // V_offset = i * k
+      xor_offset += pprf_range_; // hash_offset = i * pprf_range
     }
   }
 
@@ -603,8 +605,8 @@ void SoftspokenOtExtReceiver::GenSfVole(const uint128_t choice,
       for (uint64_t j = 0; j < k_limit; ++j) {
         W[W_offset + j] = xor_buff[xor_offset + 1 + j];
       }
-      W_offset += k_;             // W_offset = i * k;
-      xor_offset += pprf_range_;  // xor_offset = i * pprf_range;
+      W_offset += k_;            // W_offset = i * k;
+      xor_offset += pprf_range_; // xor_offset = i * pprf_range;
     }
   }
   if (compact_) {
@@ -614,14 +616,14 @@ void SoftspokenOtExtReceiver::GenSfVole(const uint128_t choice,
 
 // old style interface
 void SoftspokenOtExtSender::Send(
-    const std::shared_ptr<link::Context>& ctx,
+    const std::shared_ptr<link::Context> &ctx,
     absl::Span<std::array<uint128_t, 2>> send_blocks, bool cot) {
   if (!inited_) {
     OneTimeSetup(ctx);
   }
 
-  const uint64_t& step = step_;
-  const auto& delta = delta_;
+  const uint64_t &step = step_;
+  const auto &delta = delta_;
   const uint64_t batch_size = kBatchSize;
   const uint64_t super_batch_size = step * batch_size;
   const uint64_t numOt = send_blocks.size();
@@ -651,7 +653,7 @@ void SoftspokenOtExtSender::Send(
     // The same as IKNP OTe, see `yacl/crypto/primitive/ot/iknp_ote_cc`
     // 1. receive the masked choices
     auto recv_buff = ctx->Recv(ctx->NextRank(), "softspoken_switch_u");
-    auto recv_U = absl::MakeSpan(static_cast<uint128_t*>(recv_buff.data()),
+    auto recv_U = absl::MakeSpan(static_cast<uint128_t *>(recv_buff.data()),
                                  recv_buff.size() / sizeof(uint128_t));
     YACL_ENFORCE(recv_U.size() == step * pprf_num_);
 
@@ -669,14 +671,16 @@ void SoftspokenOtExtSender::Send(
       XorBlock(absl::MakeSpan(V[s]), absl::MakeSpan(V_xor_delta[s]), delta);
       // 4. perform CrHash to break the correlation if cot flag is false
       if (!cot) {
-      	// use TCCR hash for malicious security, or CR for semi-honest
+        // use TCCR hash for malicious security, or CR for semi-honest
         if (mal_) {
-          ParaTccrHashInplace_128(absl::MakeSpan(V[s]), t * super_batch_size + s * kBatchSize);
-          ParaTccrHashInplace_128(absl::MakeSpan(V_xor_delta[s]), t * super_batch_size + s * kBatchSize);
-		} else {
+          ParaTccrHashInplace_128(absl::MakeSpan(V[s]),
+                                  t * super_batch_size + s * kBatchSize);
+          ParaTccrHashInplace_128(absl::MakeSpan(V_xor_delta[s]),
+                                  t * super_batch_size + s * kBatchSize);
+        } else {
           ParaCrHashInplace_128(absl::MakeSpan(V[s]));
           ParaCrHashInplace_128(absl::MakeSpan(V_xor_delta[s]));
-		}
+        }
       }
 
       for (uint64_t j = 0; j < kBatchSize; ++j) {
@@ -692,7 +696,7 @@ void SoftspokenOtExtSender::Send(
     // The same as IKNP OTe
     // 1. receive the masked choices
     auto recv_buff = ctx->Recv(ctx->NextRank(), "softspoken_switch_u");
-    auto recv_U = absl::MakeSpan(static_cast<uint128_t*>(recv_buff.data()),
+    auto recv_U = absl::MakeSpan(static_cast<uint128_t *>(recv_buff.data()),
                                  recv_buff.size() / sizeof(uint128_t));
     YACL_ENFORCE(recv_U.size() == pprf_num_);
 
@@ -709,14 +713,16 @@ void SoftspokenOtExtSender::Send(
       XorBlock(absl::MakeSpan(V[t]), absl::MakeSpan(V_xor_delta[t]), delta);
       // 4. perform CrHash to break the correlation if cot flag is false
       if (!cot) {
-      	// use TCCR hash for malicious security, or CR for semi-honest
-      	if (mal_) {
-          ParaTccrHashInplace_128(absl::MakeSpan(V[t]), batch_offset + t * kBatchSize);
-          ParaTccrHashInplace_128(absl::MakeSpan(V_xor_delta[t]), batch_offset + t * kBatchSize);	
-		} else {
+        // use TCCR hash for malicious security, or CR for semi-honest
+        if (mal_) {
+          ParaTccrHashInplace_128(absl::MakeSpan(V[t]),
+                                  batch_offset + t * kBatchSize);
+          ParaTccrHashInplace_128(absl::MakeSpan(V_xor_delta[t]),
+                                  batch_offset + t * kBatchSize);
+        } else {
           ParaCrHashInplace_128(absl::MakeSpan(V[t]));
           ParaCrHashInplace_128(absl::MakeSpan(V_xor_delta[t]));
-		}
+        }
       }
 
       const uint64_t limit =
@@ -741,7 +747,8 @@ void SoftspokenOtExtSender::Send(
       for (size_t k = 0; k < kKappa; ++k) {
         check_msgs.t[k] ^= math::Gf64ClMul(
             absl::MakeSpan(rand_samples.data() + i * 2, 2),
-            absl::MakeSpan(reinterpret_cast<uint64_t*>(allV[i].data() + k), 2));
+            absl::MakeSpan(reinterpret_cast<uint64_t *>(allV[i].data() + k),
+                           2));
       }
     }
 
@@ -760,15 +767,15 @@ void SoftspokenOtExtSender::Send(
   }
 }
 
-void SoftspokenOtExtSender::Send(const std::shared_ptr<link::Context>& ctx,
-                                 OtSendStore* out) {
+void SoftspokenOtExtSender::Send(const std::shared_ptr<link::Context> &ctx,
+                                 OtSendStore *out) {
   YACL_ENFORCE(out->Type() == OtStoreType::Compact);
 
   if (!inited_) {
     OneTimeSetup(ctx);
   }
 
-  const uint64_t& step = step_;
+  const uint64_t &step = step_;
   const uint64_t batch_size = kBatchSize;
   const uint64_t super_batch_size = step * batch_size;
   const uint64_t numOt = out->Size();
@@ -800,7 +807,7 @@ void SoftspokenOtExtSender::Send(const std::shared_ptr<link::Context>& ctx,
     // The same as IKNP OTe, see `yacl/crypto/primitive/ot/iknp_ote_cc`
     // 1. receive the masked choices
     auto recv_buff = ctx->Recv(ctx->NextRank(), "softspoken_switch_u");
-    auto recv_U = absl::MakeSpan(static_cast<uint128_t*>(recv_buff.data()),
+    auto recv_U = absl::MakeSpan(static_cast<uint128_t *>(recv_buff.data()),
                                  recv_buff.size() / sizeof(uint128_t));
     YACL_ENFORCE(recv_U.size() == step * pprf_num_);
 
@@ -828,7 +835,7 @@ void SoftspokenOtExtSender::Send(const std::shared_ptr<link::Context>& ctx,
     // The same as IKNP OTe
     // 1. receive the masked choices
     auto recv_buff = ctx->Recv(ctx->NextRank(), "softspoken_switch_u");
-    auto recv_U = absl::MakeSpan(static_cast<uint128_t*>(recv_buff.data()),
+    auto recv_U = absl::MakeSpan(static_cast<uint128_t *>(recv_buff.data()),
                                  recv_buff.size() / sizeof(uint128_t));
     YACL_ENFORCE(recv_U.size() == pprf_num_);
 
@@ -864,7 +871,8 @@ void SoftspokenOtExtSender::Send(const std::shared_ptr<link::Context>& ctx,
       for (size_t k = 0; k < kKappa; ++k) {
         check_msgs.t[k] ^= math::Gf64ClMul(
             absl::MakeSpan(rand_samples.data() + i * 2, 2),
-            absl::MakeSpan(reinterpret_cast<uint64_t*>(allV[i].data() + k), 2));
+            absl::MakeSpan(reinterpret_cast<uint64_t *>(allV[i].data() + k),
+                           2));
       }
     }
 
@@ -883,9 +891,9 @@ void SoftspokenOtExtSender::Send(const std::shared_ptr<link::Context>& ctx,
   }
 }
 
-void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
-                                   const dynamic_bitset<uint128_t>& choices,
-                                   /* compact cot */ OtRecvStore* out) {
+void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context> &ctx,
+                                   const dynamic_bitset<uint128_t> &choices,
+                                   /* compact cot */ OtRecvStore *out) {
   YACL_ENFORCE(out->Type() == OtStoreType::Compact);
 
   if (!inited_) {
@@ -893,7 +901,7 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
   }
 
   YACL_ENFORCE(choices.size() == out->Size());
-  const uint64_t& step = step_;
+  const uint64_t &step = step_;
   const uint64_t batch_size = kBatchSize;
   const uint64_t super_batch_size = step * batch_size;
   const uint64_t numOt = out->Size();
@@ -940,7 +948,7 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
     }
   }
 
-  // deal with normal batch 
+  // deal with normal batch
   for (uint64_t t = 0; t < batch_num; ++t) {
     // The same as IKNP OTe
     // 1. smallfield/subspace VOLE
@@ -976,14 +984,15 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
 
     CheckMsg<uint128_t> check_msgs;
     auto choice_span = absl::MakeSpan(
-        reinterpret_cast<uint64_t*>(choice_ext.data()), all_batch_num * 2);
+        reinterpret_cast<uint64_t *>(choice_ext.data()), all_batch_num * 2);
     check_msgs.x ^= math::Gf64ClMul(absl::MakeSpan(rand_samples), choice_span);
 
     for (size_t i = 0; i < all_batch_num; ++i) {
       for (size_t k = 0; k < kKappa; ++k) {
         check_msgs.t[k] ^= math::Gf64ClMul(
             absl::MakeSpan(rand_samples.data() + i * 2, 2),
-            absl::MakeSpan(reinterpret_cast<uint64_t*>(allW[i].data() + k), 2));
+            absl::MakeSpan(reinterpret_cast<uint64_t *>(allW[i].data() + k),
+                           2));
       }
     }
 
@@ -998,8 +1007,8 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
 }
 
 // old style interface
-void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
-                                   const dynamic_bitset<uint128_t>& choices,
+void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context> &ctx,
+                                   const dynamic_bitset<uint128_t> &choices,
                                    absl::Span<uint128_t> recv_blocks,
                                    bool cot) {
   if (!inited_) {
@@ -1007,7 +1016,7 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
   }
 
   YACL_ENFORCE(choices.size() == recv_blocks.size());
-  const uint64_t& step = step_;
+  const uint64_t &step = step_;
   const uint64_t batch_size = kBatchSize;
   const uint64_t super_batch_size = step * batch_size;
   const uint64_t numOt = recv_blocks.size();
@@ -1050,12 +1059,13 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
       MatrixTranspose128(&W[s]);
       // 4. perform CrHash to break the correlation if cot flag is false
       if (!cot) {
-      	// use TCCR hash for malicious security, or CR for semi-honest
+        // use TCCR hash for malicious security, or CR for semi-honest
         if (mal_) {
-          ParaTccrHashInplace_128(absl::MakeSpan(W[s]), t * super_batch_size + s * batch_size);
-		} else {
+          ParaTccrHashInplace_128(absl::MakeSpan(W[s]),
+                                  t * super_batch_size + s * batch_size);
+        } else {
           ParaCrHashInplace_128(absl::MakeSpan(W[s]));
-		}
+        }
       }
       for (uint64_t j = 0; j < kBatchSize; ++j) {
         recv_blocks[t * super_batch_size + s * batch_size + j] = W[s][j];
@@ -1085,12 +1095,13 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
           std::min(kBatchSize, numOt - batch_offset - t * kBatchSize);
       // 4. perform CrHash to break the correlation if cot flag is false
       if (!cot) {
-      	// use TCCR hash for malicious security, or CR for semi-honest
-      	if (mal_) {
-          ParaTccrHashInplace_128(absl::MakeSpan(W[t]), batch_offset + t * kBatchSize);
-		} else {
+        // use TCCR hash for malicious security, or CR for semi-honest
+        if (mal_) {
+          ParaTccrHashInplace_128(absl::MakeSpan(W[t]),
+                                  batch_offset + t * kBatchSize);
+        } else {
           ParaCrHashInplace_128(absl::MakeSpan(W[t]));
-		}
+        }
       }
       for (uint64_t j = 0; j < limit; ++j) {
         recv_blocks[batch_offset + t * kBatchSize + j] = W[t][j];
@@ -1108,14 +1119,15 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
 
     CheckMsg<uint128_t> check_msgs;
     auto choice_span = absl::MakeSpan(
-        reinterpret_cast<uint64_t*>(choice_ext.data()), all_batch_num * 2);
+        reinterpret_cast<uint64_t *>(choice_ext.data()), all_batch_num * 2);
     check_msgs.x ^= math::Gf64ClMul(absl::MakeSpan(rand_samples), choice_span);
 
     for (size_t i = 0; i < all_batch_num; ++i) {
       for (size_t k = 0; k < kKappa; ++k) {
         check_msgs.t[k] ^= math::Gf64ClMul(
             absl::MakeSpan(rand_samples.data() + i * 2, 2),
-            absl::MakeSpan(reinterpret_cast<uint64_t*>(allW[i].data() + k), 2));
+            absl::MakeSpan(reinterpret_cast<uint64_t *>(allW[i].data() + k),
+                           2));
       }
     }
 
@@ -1129,4 +1141,4 @@ void SoftspokenOtExtReceiver::Recv(const std::shared_ptr<link::Context>& ctx,
   }
 }
 
-}  // namespace yacl::crypto
+} // namespace yacl::crypto

--- a/yacl/kernel/ot_kernel.cc
+++ b/yacl/kernel/ot_kernel.cc
@@ -42,7 +42,7 @@ using OtMsg = uint128_t;
 using OtMsgPair = std::array<OtMsg, 2>;
 using OtChoices = dynamic_bitset<uint128_t>;
 
-// Inplace-conversion from cot to rot
+// Inplace-conversion from cot to rot (sender function)
 void naive_cot2rot(const OtSendStore& cot_store, OtSendStore* rot_store) {
   YACL_ENFORCE(cot_store.Size() == rot_store->Size());     // size should match
   YACL_ENFORCE(cot_store.Type() == OtStoreType::Compact);  // compact mode
@@ -50,13 +50,13 @@ void naive_cot2rot(const OtSendStore& cot_store, OtSendStore* rot_store) {
   const uint32_t ot_num = cot_store.Size();  // warning: narrow conversion
   parallel_for(0, ot_num, 1, [&](uint64_t beg, uint64_t end) {
     for (uint64_t i = beg; i < end; ++i) {
-      rot_store->SetNormalBlock(i, 0, CrHash_128(cot_store.GetBlock(i, 0)));
-      rot_store->SetNormalBlock(i, 1, CrHash_128(cot_store.GetBlock(i, 1)));
+      rot_store->SetNormalBlock(i, 0, TccrHash_128(cot_store.GetBlock(i, 0), i));
+      rot_store->SetNormalBlock(i, 1, TccrHash_128(cot_store.GetBlock(i, 1), i));
     }
   });
 }
 
-// Inplace-conversion from cot to rot
+// Inplace-conversion from cot to rot (receiver function)
 void naive_cot2rot(const OtRecvStore& cot_store, OtRecvStore* rot_store) {
   const uint32_t ot_num = cot_store.Size();  // warning: narrow conversion
   YACL_ENFORCE(cot_store.Type() == OtStoreType::Compact);  // compact mode
@@ -66,7 +66,7 @@ void naive_cot2rot(const OtRecvStore& cot_store, OtRecvStore* rot_store) {
 
   parallel_for(0, ot_num, 1, [&](uint64_t beg, uint64_t end) {
     for (uint64_t i = beg; i < end; ++i) {
-      rot_store->SetBlock(i, CrHash_128(cot_store.GetBlock(i)));
+      rot_store->SetBlock(i, TccrHash_128(cot_store.GetBlock(i), i));
     }
   });
 }

--- a/yacl/kernel/ot_kernel.cc
+++ b/yacl/kernel/ot_kernel.cc
@@ -42,7 +42,7 @@ using OtMsg = uint128_t;
 using OtMsgPair = std::array<OtMsg, 2>;
 using OtChoices = dynamic_bitset<uint128_t>;
 
-// Inplace-conversion from cot to rot (sender function)
+// Inplace-conversion from cot to rot
 void naive_cot2rot(const OtSendStore& cot_store, OtSendStore* rot_store) {
   YACL_ENFORCE(cot_store.Size() == rot_store->Size());     // size should match
   YACL_ENFORCE(cot_store.Type() == OtStoreType::Compact);  // compact mode
@@ -50,13 +50,13 @@ void naive_cot2rot(const OtSendStore& cot_store, OtSendStore* rot_store) {
   const uint32_t ot_num = cot_store.Size();  // warning: narrow conversion
   parallel_for(0, ot_num, 1, [&](uint64_t beg, uint64_t end) {
     for (uint64_t i = beg; i < end; ++i) {
-      rot_store->SetNormalBlock(i, 0, TccrHash_128(cot_store.GetBlock(i, 0), i));
-      rot_store->SetNormalBlock(i, 1, TccrHash_128(cot_store.GetBlock(i, 1), i));
+      rot_store->SetNormalBlock(i, 0, CrHash_128(cot_store.GetBlock(i, 0)));
+      rot_store->SetNormalBlock(i, 1, CrHash_128(cot_store.GetBlock(i, 1)));
     }
   });
 }
 
-// Inplace-conversion from cot to rot (receiver function)
+// Inplace-conversion from cot to rot
 void naive_cot2rot(const OtRecvStore& cot_store, OtRecvStore* rot_store) {
   const uint32_t ot_num = cot_store.Size();  // warning: narrow conversion
   YACL_ENFORCE(cot_store.Type() == OtStoreType::Compact);  // compact mode
@@ -66,7 +66,7 @@ void naive_cot2rot(const OtRecvStore& cot_store, OtRecvStore* rot_store) {
 
   parallel_for(0, ot_num, 1, [&](uint64_t beg, uint64_t end) {
     for (uint64_t i = beg; i < end; ++i) {
-      rot_store->SetBlock(i, TccrHash_128(cot_store.GetBlock(i), i));
+      rot_store->SetBlock(i, CrHash_128(cot_store.GetBlock(i)));
     }
   });
 }


### PR DESCRIPTION
In conversion from COT to ROT, the hash function used for breaking correlation must be Tweakable Correlation Robust (TCR) to ensure malicious security. This fix implements the Tweakable Circular Correlation Robust (TCCR) hash function according to GKWY20 paper Sec 7.4 (https://eprint.iacr.org/2019/074.pdf). A TCCR function is also TCR.

I have read the CLA Document and I hereby sign the CLA